### PR TITLE
THT version of the board design

### DIFF
--- a/ExpansionBoards/KL25Z-Adapter/PinscapePico KL25Z Adapter - 74HC165 vsn.brd
+++ b/ExpansionBoards/KL25Z-Adapter/PinscapePico KL25Z Adapter - 74HC165 vsn.brd
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.7.0">
+<eagle version="9.6.2">
 <drawing>
 <settings>
-<setting alwaysvectorfont="yes"/>
+<setting alwaysvectorfont="no"/>
+<setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
 <grid distance="0.05" unitdist="mm" unit="mm" style="lines" multiple="1" display="no" altdistance="0.025" altunitdist="inch" altunit="inch"/>
@@ -25,7 +26,7 @@
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
 <layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
 <layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
@@ -40,13 +41,13 @@
 <layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
 <layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
 <layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
-<layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
 <layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
 <layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
-<layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
 <layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
@@ -58,8 +59,8 @@
 <layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
 <layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
 <layer number="61" name="stand" color="7" fill="1" visible="no" active="no"/>
-<layer number="88" name="SimResults" color="9" fill="1" visible="yes" active="yes"/>
-<layer number="89" name="SimProbes" color="9" fill="1" visible="yes" active="yes"/>
+<layer number="88" name="SimResults" color="9" fill="1" visible="no" active="no"/>
+<layer number="89" name="SimProbes" color="9" fill="1" visible="no" active="no"/>
 <layer number="90" name="Modules" color="5" fill="1" visible="no" active="no"/>
 <layer number="91" name="Nets" color="2" fill="1" visible="no" active="no"/>
 <layer number="92" name="Busses" color="1" fill="1" visible="no" active="no"/>
@@ -70,8 +71,8 @@
 <layer number="97" name="Info" color="7" fill="1" visible="no" active="no"/>
 <layer number="98" name="Guide" color="6" fill="1" visible="no" active="no"/>
 <layer number="99" name="SpiceOrder" color="5" fill="1" visible="no" active="no"/>
-<layer number="100" name="US-Transistor" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="101" name="EU-Transistor" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="100" name="US-Transistor" color="7" fill="1" visible="no" active="yes"/>
+<layer number="101" name="EU-Transistor" color="7" fill="1" visible="no" active="yes"/>
 <layer number="102" name="Vscore" color="7" fill="1" visible="no" active="yes"/>
 <layer number="103" name="fp3" color="7" fill="1" visible="no" active="yes"/>
 <layer number="104" name="Name" color="7" fill="1" visible="no" active="yes"/>
@@ -178,19 +179,24 @@
 </layers>
 <board>
 <plain>
-<text x="27.15" y="42.65" size="2.1844" layer="25" ratio="12" align="center">RESET</text>
+<text x="27.15" y="42.65" size="2.1844" layer="25" align="center">RESET</text>
 <text x="25.1" y="27.05" size="2.1844" layer="25" ratio="15" align="center">RASPBERRY PI PICO</text>
-<text x="63.85" y="9.3" size="1.5" layer="25" ratio="15" distance="25" align="center-right">PINSCAPE PICO
+<text x="63.85" y="8.45" size="1.5" layer="25" ratio="15" distance="25" align="center-right">PINSCAPE PICO
 KL25Z EXPANSION BOARD ADAPTER
 </text>
-<text x="5.45" y="51.95" size="1" layer="25" ratio="15" distance="25" align="center-left">REV 20250129</text>
+<text x="15.3" y="51.35" size="1" layer="25" ratio="15" distance="25" align="center-right"> REV 20250125
+V1.4a</text>
 <wire x1="7.45" y1="53.3" x2="74.1" y2="53.25" width="0" layer="20"/>
 <wire x1="74.1" y1="53.25" x2="82.2" y2="45.25" width="0" layer="20" curve="-90.026193"/>
 <wire x1="82.2" y1="45.25" x2="82.2" y2="8.45" width="0" layer="20"/>
 <wire x1="82.2" y1="8.45" x2="74.3" y2="0.25" width="0" layer="20" curve="-85.71198"/>
 <wire x1="74.3" y1="0.25" x2="7.15" y2="0.2" width="0" layer="20"/>
 <wire x1="7.15" y1="0.2" x2="-0.4" y2="8.1" width="0" layer="20" curve="-79.191431"/>
-<wire x1="-0.4" y1="8.1" x2="-0.4" y2="45.45" width="0" layer="20"/>
+<wire x1="-0.4" y1="8.1" x2="-0.4" y2="18.4" width="0" layer="20"/>
+<wire x1="-0.4" y1="18.4" x2="0.9" y2="19.7" width="0" layer="20"/>
+<wire x1="0.9" y1="19.7" x2="0.9" y2="32.05" width="0" layer="20"/>
+<wire x1="0.9" y1="32.05" x2="-0.4" y2="33.35" width="0" layer="20"/>
+<wire x1="-0.4" y1="33.35" x2="-0.4" y2="45.45" width="0" layer="20"/>
 <wire x1="-0.4" y1="45.45" x2="7.45" y2="53.3" width="0" layer="20" curve="-87.084271"/>
 </plain>
 <libraries>
@@ -199,62 +205,62 @@ KL25Z EXPANSION BOARD ADAPTER
 &lt;h4&gt;SMD &amp; Through Hole Footprints&lt;/h4&gt;
 &lt;h4&gt;Pinout Based Schematic Symbol.</description>
 <packages>
-<package name="RPI_PICO">
-<wire x1="-11.262" y1="25.5" x2="-4" y2="25.5" width="0.127" layer="21"/>
-<wire x1="-4" y1="25.5" x2="4" y2="25.5" width="0.127" layer="21"/>
-<wire x1="4" y1="25.5" x2="11.262" y2="25.5" width="0.127" layer="21"/>
-<wire x1="11.262" y1="25.5" x2="11.262" y2="-26.008" width="0.127" layer="21"/>
-<wire x1="11.262" y1="-26.008" x2="-11.262" y2="-26.008" width="0.127" layer="21"/>
-<wire x1="-11.262" y1="-26.008" x2="-11.262" y2="25.5" width="0.127" layer="21"/>
+<package name="RPI_PICO_TH">
+<wire x1="-10.5" y1="25.5" x2="-4" y2="25.5" width="0.127" layer="21"/>
+<wire x1="-4" y1="25.5" x2="3.9" y2="25.5" width="0.127" layer="21"/>
+<wire x1="3.9" y1="25.5" x2="10.5" y2="25.5" width="0.127" layer="21"/>
+<wire x1="10.5" y1="25.5" x2="10.5" y2="-25.5" width="0.127" layer="21"/>
+<wire x1="10.5" y1="-25.5" x2="-10.5" y2="-25.5" width="0.127" layer="21"/>
+<wire x1="-10.5" y1="-25.5" x2="-10.5" y2="25.5" width="0.127" layer="21"/>
 <wire x1="-4" y1="25.5" x2="-4" y2="27" width="0.127" layer="21"/>
 <wire x1="-4" y1="27" x2="4" y2="27" width="0.127" layer="21"/>
-<wire x1="4" y1="27" x2="4" y2="25.5" width="0.127" layer="21"/>
+<wire x1="4" y1="27" x2="3.9" y2="25.5" width="0.127" layer="21"/>
 <wire x1="-4" y1="25.5" x2="-4" y2="21" width="0.127" layer="21"/>
 <wire x1="-4" y1="21" x2="4" y2="21" width="0.127" layer="21"/>
-<wire x1="4" y1="21" x2="4" y2="25.5" width="0.127" layer="21"/>
-<smd name="VBUS" x="9.525" y="24.13" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="VSYS" x="9.525" y="21.59" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GND@8" x="9.525" y="19.05" dx="1.6" dy="3.2" layer="1" rot="R90"/>
-<smd name="3V3_EN" x="9.525" y="16.51" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="3V3" x="9.525" y="13.97" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="ADC_VREF" x="9.525" y="11.43" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP28_A2" x="9.525" y="8.89" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="AGND" x="9.525" y="6.35" dx="1.6" dy="3.2" layer="1" rot="R90"/>
-<smd name="GP27_A1" x="9.525" y="3.81" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP26_A0" x="9.525" y="1.27" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="RUN" x="9.525" y="-1.27" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP22" x="9.525" y="-3.81" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GND@7" x="9.525" y="-6.35" dx="1.6" dy="3.2" layer="1" rot="R90"/>
-<smd name="GP21" x="9.525" y="-8.89" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP20" x="9.525" y="-11.43" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP19" x="9.525" y="-13.97" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP18" x="9.525" y="-16.51" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GND@6" x="9.525" y="-19.05" dx="1.6" dy="3.2" layer="1" rot="R90"/>
-<smd name="GP17" x="9.525" y="-21.59" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP16" x="9.525" y="-24.13" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP15" x="-9.525" y="-24.13" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP14" x="-9.525" y="-21.59" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GND@4" x="-9.525" y="-19.05" dx="1.6" dy="3.2" layer="1" rot="R90"/>
-<smd name="GP13" x="-9.525" y="-16.51" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP12" x="-9.525" y="-13.97" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP11" x="-9.525" y="-11.43" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP10" x="-9.525" y="-8.89" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GND@3" x="-9.525" y="-6.35" dx="1.6" dy="3.2" layer="1" rot="R90"/>
-<smd name="GP9" x="-9.525" y="-3.81" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP8" x="-9.525" y="-1.27" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP7" x="-9.525" y="1.27" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP6" x="-9.525" y="3.81" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GND@2" x="-9.525" y="6.35" dx="1.6" dy="3.2" layer="1" rot="R90"/>
-<smd name="GP5" x="-9.525" y="8.89" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP4" x="-9.525" y="11.43" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP3" x="-9.525" y="13.97" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP2" x="-9.525" y="16.51" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GND@1" x="-9.525" y="19.05" dx="1.6" dy="3.2" layer="1" rot="R90"/>
-<smd name="GP1" x="-9.525" y="21.59" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GP0" x="-9.525" y="24.13" dx="1.6" dy="3.2" layer="1" roundness="100" rot="R90"/>
-<smd name="GND@5" x="0" y="-24.13" dx="1.6" dy="3.2" layer="1" roundness="100"/>
-<smd name="SWCLK" x="-2.54" y="-24.13" dx="1.6" dy="3.2" layer="1" roundness="100"/>
-<smd name="SWDIO" x="2.54" y="-24.13" dx="1.6" dy="3.2" layer="1" roundness="100"/>
+<wire x1="4" y1="21" x2="3.9" y2="25.5" width="0.127" layer="21"/>
+<pad name="GP0" x="-8.89" y="24.13" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP1" x="-8.89" y="21.59" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GND@1" x="-8.89" y="19.05" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP2" x="-8.89" y="16.51" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP3" x="-8.89" y="13.97" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP4" x="-8.89" y="11.43" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP5" x="-8.89" y="8.89" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GND@2" x="-8.89" y="6.35" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP6" x="-8.89" y="3.81" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP7" x="-8.89" y="1.27" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP8" x="-8.89" y="-1.27" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP9" x="-8.89" y="-3.81" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GND@3" x="-8.89" y="-6.35" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP10" x="-8.89" y="-8.89" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP11" x="-8.89" y="-11.43" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP12" x="-8.89" y="-13.97" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP13" x="-8.89" y="-16.51" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GND@4" x="-8.89" y="-19.05" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP14" x="-8.89" y="-21.59" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP15" x="-8.89" y="-24.13" drill="1.1" diameter="1.6" shape="offset" rot="R180"/>
+<pad name="GP16" x="8.89" y="-24.13" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GP17" x="8.89" y="-21.59" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GND@6" x="8.89" y="-19.05" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GP18" x="8.89" y="-16.51" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GP19" x="8.89" y="-13.97" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GP20" x="8.89" y="-11.43" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GP21" x="8.89" y="-8.89" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GND@7" x="8.89" y="-6.35" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GP22" x="8.89" y="-3.81" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="RUN" x="8.89" y="-1.27" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GP26_A0" x="8.89" y="1.27" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GP27_A1" x="8.89" y="3.81" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="AGND" x="8.89" y="6.35" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GP28_A2" x="8.89" y="8.89" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="ADC_VREF" x="8.89" y="11.43" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="3V3" x="8.89" y="13.97" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="3V3_EN" x="8.89" y="16.51" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="GND@8" x="8.89" y="19.05" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="VSYS" x="8.89" y="21.59" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="VBUS" x="8.89" y="24.13" drill="1.1" diameter="1.6" shape="offset"/>
+<pad name="SWCLK" x="-2.54" y="-23.9" drill="1.1" diameter="1.6" shape="offset" rot="R270"/>
+<pad name="GND@5" x="0" y="-23.9" drill="1.1" diameter="1.6" shape="offset" rot="R270"/>
+<pad name="SWDIO" x="2.54" y="-23.9" drill="1.1" diameter="1.6" shape="offset" rot="R270"/>
 </package>
 </packages>
 </library>
@@ -792,43 +798,6 @@ KL25Z EXPANSION BOARD ADAPTER
 <wire x1="-1.6" y1="-4.95" x2="-1.6" y2="4.95" width="0.2" layer="21"/>
 <wire x1="-3.475" y1="5.12" x2="-1.95" y2="5.12" width="0.2" layer="21"/>
 </package>
-<package name="EXBE10C103J">
-<description>&lt;b&gt;EXB-E&lt;/b&gt;&lt;br&gt;
-</description>
-<smd name="1" x="-2.137" y="0" dx="0.925" dy="0.45" layer="1"/>
-<smd name="2" x="-1.2" y="-1.188" dx="0.925" dy="0.375" layer="1" rot="R90"/>
-<smd name="3" x="-0.4" y="-1.188" dx="0.925" dy="0.375" layer="1" rot="R90"/>
-<smd name="4" x="0.4" y="-1.188" dx="0.925" dy="0.375" layer="1" rot="R90"/>
-<smd name="5" x="1.2" y="-1.188" dx="0.925" dy="0.375" layer="1" rot="R90"/>
-<smd name="6" x="2.137" y="0" dx="0.925" dy="0.45" layer="1"/>
-<smd name="7" x="1.2" y="1.188" dx="0.925" dy="0.375" layer="1" rot="R90"/>
-<smd name="8" x="0.4" y="1.188" dx="0.925" dy="0.375" layer="1" rot="R90"/>
-<smd name="9" x="-0.4" y="1.188" dx="0.925" dy="0.375" layer="1" rot="R90"/>
-<smd name="10" x="-1.2" y="1.188" dx="0.925" dy="0.375" layer="1" rot="R90"/>
-<text x="0" y="0" size="1.27" layer="25" align="center">&gt;NAME</text>
-<text x="0" y="0" size="1.27" layer="27" align="center">&gt;VALUE</text>
-<wire x1="-2" y1="1.05" x2="2" y2="1.05" width="0.2" layer="51"/>
-<wire x1="2" y1="1.05" x2="2" y2="-1.05" width="0.2" layer="51"/>
-<wire x1="2" y1="-1.05" x2="-2" y2="-1.05" width="0.2" layer="51"/>
-<wire x1="-2" y1="-1.05" x2="-2" y2="1.05" width="0.2" layer="51"/>
-<wire x1="-3.3" y1="2.35" x2="3.3" y2="2.35" width="0.1" layer="51"/>
-<wire x1="3.3" y1="2.35" x2="3.3" y2="-2.35" width="0.1" layer="51"/>
-<wire x1="3.3" y1="-2.35" x2="-3.3" y2="-2.35" width="0.1" layer="51"/>
-<wire x1="-3.3" y1="-2.35" x2="-3.3" y2="2.35" width="0.1" layer="51"/>
-<wire x1="-1.75" y1="-1.05" x2="-2" y2="-1.05" width="0.1" layer="21"/>
-<wire x1="-2" y1="-1.05" x2="-2" y2="-0.744" width="0.1" layer="21"/>
-<wire x1="-2" y1="0.74" x2="-2" y2="1" width="0.1" layer="21"/>
-<wire x1="-2" y1="1" x2="-2" y2="1.05" width="0.1" layer="21"/>
-<wire x1="-2" y1="1.05" x2="-1.75" y2="1.05" width="0.1" layer="21"/>
-<wire x1="1.75" y1="1.05" x2="2" y2="1.05" width="0.1" layer="21"/>
-<wire x1="2" y1="1.05" x2="2" y2="0.74" width="0.1" layer="21"/>
-<wire x1="1.75" y1="-1.05" x2="2" y2="-1.05" width="0.1" layer="21"/>
-<wire x1="2" y1="-1.05" x2="2" y2="-0.75" width="0.1" layer="21"/>
-<wire x1="-2.9" y1="0" x2="-2.9" y2="0" width="0.1" layer="21"/>
-<wire x1="-2.9" y1="0" x2="-3" y2="0" width="0.1" layer="21" curve="180"/>
-<wire x1="-3" y1="0" x2="-3" y2="0" width="0.1" layer="21"/>
-<wire x1="-3" y1="0" x2="-2.9" y2="0" width="0.1" layer="21" curve="180"/>
-</package>
 <package name="SOP65P640X110-24N">
 <description>&lt;b&gt;TSSOP24&lt;/b&gt;&lt;br&gt;
 </description>
@@ -875,7 +844,7 @@ KL25Z EXPANSION BOARD ADAPTER
 </package>
 </packages>
 </library>
-<library name="rcl">
+<library name="rcl" urn="urn:adsk.eagle:library:334">
 <description>&lt;b&gt;Resistors, Capacitors, Inductors&lt;/b&gt;&lt;p&gt;
 Based on the previous libraries:
 &lt;ul&gt;
@@ -1924,7 +1893,7 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 &lt;/tr&gt;
 &lt;/table&gt;</description>
 <packages>
-<package name="C1206">
+<package name="C1206" urn="urn:adsk.eagle:footprint:23125/1" library_version="11">
 <description>&lt;b&gt;CAPACITOR&lt;/b&gt;</description>
 <wire x1="-2.473" y1="0.983" x2="2.473" y2="0.983" width="0.0508" layer="39"/>
 <wire x1="2.473" y1="-0.983" x2="-2.473" y2="-0.983" width="0.0508" layer="39"/>
@@ -1934,17 +1903,21 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 <wire x1="-0.965" y1="-0.787" x2="0.965" y2="-0.787" width="0.1016" layer="51"/>
 <smd name="1" x="-1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
 <smd name="2" x="1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
-<text x="3.067" y="0.01" size="0.8" layer="25" rot="R90" align="center">&gt;NAME</text>
-<text x="-3.064" y="0.03" size="0.8" layer="27" rot="R90" align="center">&gt;VALUE</text>
+<text x="-1.27" y="1.27" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.27" y="-2.54" size="1.27" layer="27">&gt;VALUE</text>
 <rectangle x1="-1.7018" y1="-0.8509" x2="-0.9517" y2="0.8491" layer="51"/>
 <rectangle x1="0.9517" y1="-0.8491" x2="1.7018" y2="0.8509" layer="51"/>
 <rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
-<wire x1="-2.54" y1="1.143" x2="2.54" y2="1.143" width="0.127" layer="21"/>
-<wire x1="2.54" y1="1.143" x2="2.54" y2="-1.143" width="0.127" layer="21"/>
-<wire x1="2.54" y1="-1.143" x2="-2.54" y2="-1.143" width="0.127" layer="21"/>
-<wire x1="-2.54" y1="-1.143" x2="-2.54" y2="1.143" width="0.127" layer="21"/>
 </package>
 </packages>
+<packages3d>
+<package3d name="C1206" urn="urn:adsk.eagle:package:23618/2" type="model" library_version="11">
+<description>CAPACITOR</description>
+<packageinstances>
+<packageinstance name="C1206"/>
+</packageinstances>
+</package3d>
+</packages3d>
 </library>
 <library name="resistor">
 <description>&lt;b&gt;Resistors, Capacitors, Inductors&lt;/b&gt;&lt;p&gt;
@@ -3038,6 +3011,145 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 </package>
 </packages>
 </library>
+<library name="resistor-net" urn="urn:adsk.eagle:library:343">
+<description>&lt;b&gt;Generic Resistor Networks&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="CTS742C083" urn="urn:adsk.eagle:footprint:24972/1" library_version="2">
+<description>&lt;b&gt;Chip Resistor Array&lt;/b&gt;&lt;p&gt;
+Source: http://www.ctscorp.com/components/Datasheets/CTSChipArrayDs.pdf</description>
+<wire x1="-1.55" y1="0.75" x2="-1.45" y2="0.75" width="0.1016" layer="51"/>
+<wire x1="-1.45" y1="0.75" x2="-1.3" y2="0.6" width="0.1016" layer="51"/>
+<wire x1="-1.3" y1="0.6" x2="-1.1" y2="0.6" width="0.1016" layer="51"/>
+<wire x1="-1.1" y1="0.6" x2="-0.95" y2="0.75" width="0.1016" layer="51"/>
+<wire x1="-0.95" y1="0.75" x2="-0.65" y2="0.75" width="0.1016" layer="51"/>
+<wire x1="-0.15" y1="0.75" x2="0.15" y2="0.75" width="0.1016" layer="51"/>
+<wire x1="0.65" y1="0.75" x2="0.95" y2="0.75" width="0.1016" layer="51"/>
+<wire x1="1.45" y1="0.75" x2="1.55" y2="0.75" width="0.1016" layer="51"/>
+<wire x1="1.55" y1="0.75" x2="1.55" y2="-0.75" width="0.1016" layer="21"/>
+<wire x1="1.55" y1="-0.75" x2="1.45" y2="-0.75" width="0.1016" layer="51"/>
+<wire x1="0.95" y1="-0.75" x2="0.65" y2="-0.75" width="0.1016" layer="51"/>
+<wire x1="0.15" y1="-0.75" x2="-0.15" y2="-0.75" width="0.1016" layer="51"/>
+<wire x1="-0.65" y1="-0.75" x2="-0.95" y2="-0.75" width="0.1016" layer="51"/>
+<wire x1="-1.45" y1="-0.75" x2="-1.55" y2="-0.75" width="0.1016" layer="51"/>
+<wire x1="-1.55" y1="-0.75" x2="-1.55" y2="0.75" width="0.1016" layer="21"/>
+<wire x1="-0.65" y1="0.75" x2="-0.5" y2="0.6" width="0.1016" layer="51"/>
+<wire x1="-0.5" y1="0.6" x2="-0.3" y2="0.6" width="0.1016" layer="51"/>
+<wire x1="-0.3" y1="0.6" x2="-0.15" y2="0.75" width="0.1016" layer="51"/>
+<wire x1="0.15" y1="0.75" x2="0.3" y2="0.6" width="0.1016" layer="51"/>
+<wire x1="0.3" y1="0.6" x2="0.5" y2="0.6" width="0.1016" layer="51"/>
+<wire x1="0.5" y1="0.6" x2="0.65" y2="0.75" width="0.1016" layer="51"/>
+<wire x1="0.95" y1="0.75" x2="1.1" y2="0.6" width="0.1016" layer="51"/>
+<wire x1="1.1" y1="0.6" x2="1.3" y2="0.6" width="0.1016" layer="51"/>
+<wire x1="1.3" y1="0.6" x2="1.45" y2="0.75" width="0.1016" layer="51"/>
+<wire x1="1.45" y1="-0.75" x2="1.3" y2="-0.6" width="0.1016" layer="51"/>
+<wire x1="1.3" y1="-0.6" x2="1.1" y2="-0.6" width="0.1016" layer="51"/>
+<wire x1="1.1" y1="-0.6" x2="0.95" y2="-0.75" width="0.1016" layer="51"/>
+<wire x1="0.65" y1="-0.75" x2="0.5" y2="-0.6" width="0.1016" layer="51"/>
+<wire x1="0.5" y1="-0.6" x2="0.3" y2="-0.6" width="0.1016" layer="51"/>
+<wire x1="0.3" y1="-0.6" x2="0.15" y2="-0.75" width="0.1016" layer="51"/>
+<wire x1="-0.15" y1="-0.75" x2="-0.3" y2="-0.6" width="0.1016" layer="51"/>
+<wire x1="-0.3" y1="-0.6" x2="-0.5" y2="-0.6" width="0.1016" layer="51"/>
+<wire x1="-0.5" y1="-0.6" x2="-0.65" y2="-0.75" width="0.1016" layer="51"/>
+<wire x1="-0.95" y1="-0.75" x2="-1.1" y2="-0.6" width="0.1016" layer="51"/>
+<wire x1="-1.1" y1="-0.6" x2="-1.3" y2="-0.6" width="0.1016" layer="51"/>
+<wire x1="-1.3" y1="-0.6" x2="-1.45" y2="-0.75" width="0.1016" layer="51"/>
+<wire x1="1.55" y1="-0.45" x2="-1.55" y2="-0.45" width="0.1016" layer="51"/>
+<wire x1="-1.55" y1="0.45" x2="1.55" y2="0.45" width="0.1016" layer="51"/>
+<smd name="1" x="-1.2" y="-0.8" dx="0.5" dy="0.9" layer="1" stop="no"/>
+<smd name="2" x="-0.4" y="-0.8" dx="0.5" dy="0.9" layer="1" stop="no"/>
+<smd name="3" x="0.4" y="-0.8" dx="0.5" dy="0.9" layer="1" stop="no"/>
+<smd name="4" x="1.2" y="-0.8" dx="0.5" dy="0.9" layer="1" stop="no"/>
+<smd name="5" x="1.2" y="0.8" dx="0.5" dy="0.9" layer="1" stop="no"/>
+<smd name="6" x="0.4" y="0.8" dx="0.5" dy="0.9" layer="1" stop="no"/>
+<smd name="7" x="-0.4" y="0.8" dx="0.5" dy="0.9" layer="1" stop="no"/>
+<smd name="8" x="-1.2" y="0.8" dx="0.5" dy="0.9" layer="1" stop="no"/>
+<text x="-1.778" y="1.524" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.778" y="-2.794" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.5" y1="-1.3" x2="-0.9" y2="-0.3" layer="29"/>
+<rectangle x1="-0.7" y1="-1.3" x2="-0.1" y2="-0.3" layer="29"/>
+<rectangle x1="0.1" y1="-1.3" x2="0.7" y2="-0.3" layer="29"/>
+<rectangle x1="0.9" y1="-1.3" x2="1.5" y2="-0.3" layer="29"/>
+<rectangle x1="0.9" y1="0.3" x2="1.5" y2="1.3" layer="29" rot="R180"/>
+<rectangle x1="0.1" y1="0.3" x2="0.7" y2="1.3" layer="29" rot="R180"/>
+<rectangle x1="-0.7" y1="0.3" x2="-0.1" y2="1.3" layer="29" rot="R180"/>
+<rectangle x1="-1.5" y1="0.3" x2="-0.9" y2="1.3" layer="29" rot="R180"/>
+<polygon width="0.1016" layer="51">
+<vertex x="-0.6" y="-0.675"/>
+<vertex x="-0.6" y="-0.45"/>
+<vertex x="-0.2" y="-0.45"/>
+<vertex x="-0.2" y="-0.675"/>
+<vertex x="-0.3" y="-0.575"/>
+<vertex x="-0.5" y="-0.575"/>
+</polygon>
+<polygon width="0.1016" layer="51">
+<vertex x="-1.4" y="-0.675"/>
+<vertex x="-1.4" y="-0.45"/>
+<vertex x="-1" y="-0.45"/>
+<vertex x="-1" y="-0.675"/>
+<vertex x="-1.1" y="-0.575"/>
+<vertex x="-1.3" y="-0.575"/>
+</polygon>
+<polygon width="0.1016" layer="51">
+<vertex x="0.2" y="-0.675"/>
+<vertex x="0.2" y="-0.45"/>
+<vertex x="0.6" y="-0.45"/>
+<vertex x="0.6" y="-0.675"/>
+<vertex x="0.5" y="-0.575"/>
+<vertex x="0.3" y="-0.575"/>
+</polygon>
+<polygon width="0.1016" layer="51">
+<vertex x="1" y="-0.675"/>
+<vertex x="1" y="-0.45"/>
+<vertex x="1.4" y="-0.45"/>
+<vertex x="1.4" y="-0.675"/>
+<vertex x="1.3" y="-0.575"/>
+<vertex x="1.1" y="-0.575"/>
+</polygon>
+<polygon width="0.1016" layer="51">
+<vertex x="1.4" y="0.675"/>
+<vertex x="1.4" y="0.45"/>
+<vertex x="1" y="0.45"/>
+<vertex x="1" y="0.675"/>
+<vertex x="1.1" y="0.575"/>
+<vertex x="1.3" y="0.575"/>
+</polygon>
+<polygon width="0.1016" layer="51">
+<vertex x="0.6" y="0.675"/>
+<vertex x="0.6" y="0.45"/>
+<vertex x="0.2" y="0.45"/>
+<vertex x="0.2" y="0.675"/>
+<vertex x="0.3" y="0.575"/>
+<vertex x="0.5" y="0.575"/>
+</polygon>
+<polygon width="0.1016" layer="51">
+<vertex x="-0.2" y="0.675"/>
+<vertex x="-0.2" y="0.45"/>
+<vertex x="-0.6" y="0.45"/>
+<vertex x="-0.6" y="0.675"/>
+<vertex x="-0.5" y="0.575"/>
+<vertex x="-0.3" y="0.575"/>
+</polygon>
+<polygon width="0.1016" layer="51">
+<vertex x="-1" y="0.675"/>
+<vertex x="-1" y="0.45"/>
+<vertex x="-1.4" y="0.45"/>
+<vertex x="-1.4" y="0.675"/>
+<vertex x="-1.3" y="0.575"/>
+<vertex x="-1.1" y="0.575"/>
+</polygon>
+</package>
+</packages>
+<packages3d>
+<package3d name="CTS742C083" urn="urn:adsk.eagle:package:24985/1" type="box" library_version="2">
+<description>Chip Resistor Array
+Source: http://www.ctscorp.com/components/Datasheets/CTSChipArrayDs.pdf</description>
+<packageinstances>
+<packageinstance name="CTS742C083"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -3047,7 +3159,7 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 <class number="0" name="default" width="0" drill="0">
 </class>
 </classes>
-<designrules name="jlcpcb-2layers">
+<designrules name="jlcpcb-2layers *">
 <description language="en">&lt;b&gt;JLCPCB design rules (2 layers)&lt;/b&gt;
 &lt;ul&gt;
 &lt;li&gt;Board thickness: 1.6mm&lt;/li&gt;
@@ -3115,10 +3227,14 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 <param name="slThermalsForVias" value="0"/>
 <param name="dpMaxLengthDifference" value="10mm"/>
 <param name="dpGapFactor" value="2.5"/>
-<param name="checkGrid" value="0"/>
 <param name="checkAngle" value="0"/>
 <param name="checkFont" value="1"/>
 <param name="checkRestrict" value="1"/>
+<param name="checkStop" value="0"/>
+<param name="checkValues" value="0"/>
+<param name="checkNames" value="1"/>
+<param name="checkWireStubs" value="1"/>
+<param name="checkPolygonWidth" value="0"/>
 <param name="useDiameter" value="13"/>
 <param name="maxErrors" value="50"/>
 </designrules>
@@ -3219,150 +3335,189 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 </pass>
 </autorouter>
 <elements>
-<element name="RASPBERRY_PI_PICO" library="RaspberryPi_Pico" package="RPI_PICO" value="" x="25.94" y="26.12" rot="R90"/>
+<element name="RASPBERRY_PI_PICO" library="RaspberryPi_Pico" package="RPI_PICO_TH" value="" x="26.44" y="26.12" smashed="yes" rot="R90"/>
 <element name="FRDM1" library="kl25z" package="FRDM_KL25Z_NORMAL" value="KL25Z" x="44.99" y="26.97" smashed="yes" rot="R270"/>
-<element name="IC4" library="SamacSys_Parts" package="LIS3DHTR" value="LIS3DHTR" x="10.95" y="7.52" smashed="yes">
-<attribute name="MANUFACTURER_PART_NUMBER" value="LIS3DHTR" x="9.68" y="7.52" size="1.778" layer="27" display="off"/>
-<attribute name="MOUSER_PART_NUMBER" value="511-LIS3DHTR" x="9.68" y="7.52" size="1.778" layer="27" display="off"/>
-<attribute name="DESCRIPTION" value="Accelerometer 3-Axis 2g/16g 1.8V LGA16 STMicroelectronics LIS3DHTR Accelerometer IC, 3-axis, I2C, SPI 1.71  3.6 V, 16-Pin LGA" x="9.68" y="7.52" size="1.778" layer="27" display="off"/>
-<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/STMicroelectronics/LIS3DHTR?qs=6la6oa3D8xzhXYax3cEo4w%3D%3D" x="9.68" y="7.52" size="1.778" layer="27" display="off"/>
-<attribute name="MANUFACTURER_NAME" value="STMicroelectronics" x="9.68" y="7.52" size="1.778" layer="27" display="off"/>
-<attribute name="HEIGHT" value="1mm" x="9.68" y="7.52" size="1.778" layer="27" display="off"/>
-<attribute name="NAME" x="10.569" y="4.26" size="1" layer="25" align="center"/>
-<attribute name="VALUE" x="12.119" y="9.88" size="0.7" layer="27" align="center"/>
+<element name="IC4" library="SamacSys_Parts" package="LIS3DHTR" value="LIS3DHTR" x="8.375" y="6.745" smashed="yes">
+<attribute name="DESCRIPTION" value="Accelerometer 3-Axis 2g/16g 1.8V LGA16 STMicroelectronics LIS3DHTR Accelerometer IC, 3-axis, I2C, SPI 1.71  3.6 V, 16-Pin LGA" x="7.105" y="6.745" size="1.778" layer="27" display="off"/>
+<attribute name="HEIGHT" value="1mm" x="7.105" y="6.745" size="1.778" layer="27" display="off"/>
+<attribute name="MANUFACTURER_NAME" value="STMicroelectronics" x="7.105" y="6.745" size="1.778" layer="27" display="off"/>
+<attribute name="MANUFACTURER_PART_NUMBER" value="LIS3DHTR" x="7.105" y="6.745" size="1.778" layer="27" display="off"/>
+<attribute name="MOUSER_PART_NUMBER" value="511-LIS3DHTR" x="7.105" y="6.745" size="1.778" layer="27" display="off"/>
+<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/STMicroelectronics/LIS3DHTR?qs=6la6oa3D8xzhXYax3cEo4w%3D%3D" x="7.105" y="6.745" size="1.778" layer="27" display="off"/>
+<attribute name="NAME" x="8.394" y="9.035" size="0.8" layer="25" align="center"/>
+<attribute name="VALUE" x="8.394" y="4.405" size="0.7" layer="27" align="center"/>
 </element>
-<element name="C1" library="rcl" package="C1206" value="0.1uF" x="78.95" y="24.8" smashed="yes" rot="R270">
-<attribute name="NAME" x="79.085" y="28.095" size="1" layer="25" align="center"/>
-<attribute name="VALUE" x="80.705" y="24.945" size="1" layer="27" rot="R90" align="center"/>
+<element name="C1" library="rcl" library_urn="urn:adsk.eagle:library:334" package="C1206" package3d_urn="urn:adsk.eagle:package:23618/2" value="0.1uF" x="79.3" y="16.75" smashed="yes" rot="R90">
+<attribute name="NAME" x="79.315" y="13.705" size="0.8" layer="25" rot="R180" align="center"/>
+<attribute name="POPULARITY" value="24" x="79.3" y="16.75" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="SPICEPREFIX" value="C" x="79.3" y="16.75" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="79.295" y="16.255" size="0.4" layer="27" rot="R180" align="top-center"/>
 </element>
-<element name="C2" library="rcl" package="C1206" value="0.1uF" x="79.05" y="35.57" smashed="yes" rot="R270">
-<attribute name="NAME" x="79.185" y="38.815" size="1" layer="25" align="center"/>
-<attribute name="VALUE" x="80.895" y="35.825" size="1" layer="27" rot="R270" align="center"/>
+<element name="C2" library="rcl" library_urn="urn:adsk.eagle:library:334" package="C1206" package3d_urn="urn:adsk.eagle:package:23618/2" value="0.1uF" x="79.3" y="28.42" smashed="yes" rot="R90">
+<attribute name="NAME" x="79.265" y="25.375" size="0.8" layer="25" rot="R180" align="center"/>
+<attribute name="POPULARITY" value="24" x="79.3" y="28.42" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="SPICEPREFIX" value="C" x="79.3" y="28.42" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="VALUE" x="79.305" y="28.865" size="0.4" layer="27" align="top-center"/>
 </element>
-<element name="C4" library="rcl" package="C1206" value="0.1uF" x="5.6" y="8.6" smashed="yes" rot="R180">
-<attribute name="NAME" x="2.405" y="8.715" size="1" layer="25" rot="R90" align="center"/>
-<attribute name="VALUE" x="5.615" y="6.895" size="0.9" layer="27" align="center"/>
+<element name="C4" library="rcl" library_urn="urn:adsk.eagle:library:334" package="C1206" package3d_urn="urn:adsk.eagle:package:23618/2" value="0.1uF" x="5.2" y="11.6" smashed="yes" rot="R180">
+<attribute name="NAME" x="5.205" y="13.165" size="0.8" layer="25" rot="R180" align="center"/>
+<attribute name="POPULARITY" value="24" x="5.2" y="11.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="SPICEPREFIX" value="C" x="5.2" y="11.6" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="VALUE" x="5.565" y="11.595" size="0.4" layer="27" rot="R90" align="center"/>
 </element>
 <element name="R3" library="resistor" package="R1206" value="300R" x="7.75" y="43.25" smashed="yes" rot="R180">
-<attribute name="NAME" x="11.985" y="43.215" size="1" layer="25" rot="R180" align="center"/>
+<attribute name="NAME" x="10.935" y="43.215" size="0.8" layer="25" rot="R270" align="center"/>
 </element>
 <element name="R1" library="resistor" package="R1206" value="100R" x="7.75" y="48.25" smashed="yes" rot="R180">
-<attribute name="NAME" x="11.885" y="48.315" size="1" layer="25" rot="R180" align="center"/>
+<attribute name="NAME" x="10.935" y="48.215" size="0.8" layer="25" rot="R270" align="center"/>
 </element>
 <element name="R2" library="resistor" package="R1206" value="100R" x="7.75" y="45.75" smashed="yes" rot="R180">
-<attribute name="NAME" x="12.035" y="45.765" size="1" layer="25" rot="R180" align="center"/>
+<attribute name="NAME" x="10.935" y="45.765" size="0.8" layer="25" rot="R270" align="center"/>
 </element>
 <element name="LED1" library="SamacSys_Parts" package="EC3528ARGB" value="EC3528ARGB" x="2.4" y="45.7" smashed="yes" rot="R90">
-<attribute name="NAME" x="2.5" y="47.775" size="1" layer="21" rot="R180" align="center"/>
-<attribute name="VALUE" x="2.5" y="43.89" size="0.55" layer="21" rot="R180" align="center"/>
+<attribute name="NAME" x="2.4" y="43.675" size="0.8" layer="21" align="center"/>
+<attribute name="VALUE" x="2.45" y="46.14" size="0.4" layer="21" rot="R180" align="center"/>
 </element>
 <element name="SW1" library="SamacSys_Parts" package="TS-1187A-B-A-B" value="TS-1187A-B-A-B" x="19.25" y="42.65" smashed="yes" rot="R180">
-<attribute name="NAME" x="16.06" y="42.85" size="1" layer="21" rot="R270" align="center"/>
+<attribute name="NAME" x="19.31" y="44.6" size="0.8" layer="21" align="center"/>
 </element>
-<element name="IC5" library="SamacSys_Parts" package="SOP50P490X110-10N" value="ADS1115IDGSR" x="69.45" y="10.65" smashed="yes">
-<attribute name="DESCRIPTION" value="16-Bit 860SPS 4-Ch Delta-Sigma ADC With PGA, Oscillator, Vref, Comparator, and I2C" x="69.45" y="10.65" size="2.1844" layer="27" display="off"/>
-<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Texas-Instruments/ADS1115IDGSR?qs=IK5e5L0zOXjKCJoVMhYO%2FQ%3D%3D" x="69.45" y="10.65" size="2.1844" layer="27" display="off"/>
-<attribute name="MOUSER_PART_NUMBER" value="595-ADS1115IDGSR" x="69.45" y="10.65" size="2.1844" layer="27" display="off"/>
-<attribute name="MANUFACTURER_NAME" value="Texas Instruments" x="69.45" y="10.65" size="2.1844" layer="27" display="off"/>
-<attribute name="MANUFACTURER_PART_NUMBER" value="ADS1115IDGSR" x="69.45" y="10.65" size="2.1844" layer="27" display="off"/>
-<attribute name="HEIGHT" value="1.1mm" x="69.45" y="10.65" size="2.1844" layer="27" display="off"/>
-<attribute name="NAME" x="69.35" y="13.39" size="1.27" layer="25" align="center"/>
-<attribute name="VALUE" x="69.25" y="8.66" size="0.65" layer="27" align="center"/>
+<element name="IC5" library="SamacSys_Parts" package="SOP50P490X110-10N" value="ADS1115IDGSR" x="15.1" y="6.75" smashed="yes">
+<attribute name="DESCRIPTION" value="16-Bit 860SPS 4-Ch Delta-Sigma ADC With PGA, Oscillator, Vref, Comparator, and I2C" x="15.1" y="6.75" size="2.1844" layer="27" display="off"/>
+<attribute name="HEIGHT" value="1.1mm" x="15.1" y="6.75" size="2.1844" layer="27" display="off"/>
+<attribute name="MANUFACTURER_NAME" value="Texas Instruments" x="15.1" y="6.75" size="2.1844" layer="27" display="off"/>
+<attribute name="MANUFACTURER_PART_NUMBER" value="ADS1115IDGSR" x="15.1" y="6.75" size="2.1844" layer="27" display="off"/>
+<attribute name="MOUSER_PART_NUMBER" value="595-ADS1115IDGSR" x="15.1" y="6.75" size="2.1844" layer="27" display="off"/>
+<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Texas-Instruments/ADS1115IDGSR?qs=IK5e5L0zOXjKCJoVMhYO%2FQ%3D%3D" x="15.1" y="6.75" size="2.1844" layer="27" display="off"/>
+<attribute name="NAME" x="15.05" y="9.04" size="0.8" layer="25" align="center"/>
+<attribute name="VALUE" x="15.1" y="5.21" size="0.65" layer="27" align="center"/>
 </element>
-<element name="C5" library="rcl" package="C1206" value="0.1uF" x="75.7" y="11.9" smashed="yes">
-<attribute name="NAME" x="78.717" y="12.16" size="0.8" layer="25" rot="R90" align="center"/>
-<attribute name="VALUE" x="75.82" y="13.586" size="0.8" layer="27" rot="R180" align="center"/>
+<element name="C5" library="rcl" library_urn="urn:adsk.eagle:library:334" package="C1206" package3d_urn="urn:adsk.eagle:package:23618/2" value="0.1uF" x="15" y="3" smashed="yes">
+<attribute name="NAME" x="14.967" y="1.51" size="0.8" layer="25" rot="R180" align="center"/>
+<attribute name="POPULARITY" value="24" x="15" y="3" size="1.778" layer="27" display="off"/>
+<attribute name="SPICEPREFIX" value="C" x="15" y="3" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="15.32" y="2.986" size="0.4" layer="27" rot="R270" align="center"/>
 </element>
-<element name="R4" library="resistor" package="R1206" value="10K" x="74.3" y="7.8" smashed="yes" rot="R90">
-<attribute name="NAME" x="74.37" y="4.634" size="0.8" layer="25" rot="R180" align="center"/>
-<attribute name="VALUE" x="78.464" y="6.37" size="0.8" layer="27" rot="R270" align="center"/>
+<element name="R4" library="resistor" package="R1206" value="10K" x="21.9" y="7" smashed="yes" rot="R180">
+<attribute name="NAME" x="21.866" y="8.72" size="0.8" layer="25" align="center"/>
+<attribute name="VALUE" x="22.23" y="7.014" size="0.5" layer="27" rot="R90" align="center"/>
 </element>
-<element name="R5" library="resistor" package="R1206" value="10K" x="76.8" y="7.8" smashed="yes" rot="R90">
-<attribute name="NAME" x="76.77" y="4.684" size="0.8" layer="25" rot="R180" align="center"/>
-<attribute name="VALUE" x="72.664" y="6.32" size="0.8" layer="27" rot="R270" align="center"/>
+<element name="R5" library="resistor" package="R1206" value="10K" x="21.9" y="3.65" smashed="yes" rot="R180">
+<attribute name="NAME" x="21.866" y="1.87" size="0.8" layer="25" align="center"/>
+<attribute name="VALUE" x="22.23" y="3.664" size="0.5" layer="27" rot="R90" align="center"/>
 </element>
-<element name="IC1" library="SamacSys_Parts" package="SOIC127P600X175-16N" value="SN74HC165DR" x="73.4" y="21.65" smashed="yes">
-<attribute name="MOUSER_PART_NUMBER" value="595-SN74HC165DR" x="73.4" y="21.65" size="2.1844" layer="27" display="off"/>
-<attribute name="MANUFACTURER_PART_NUMBER" value="SN74HC165DR" x="73.4" y="21.65" size="2.1844" layer="27" display="off"/>
-<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Texas-Instruments/SN74HC165DR?qs=vxEfx8VrU7AaZtng63yj8Q%3D%3D" x="73.4" y="21.65" size="2.1844" layer="27" display="off"/>
-<attribute name="MANUFACTURER_NAME" value="Texas Instruments" x="73.4" y="21.65" size="2.1844" layer="27" display="off"/>
-<attribute name="HEIGHT" value="1.75mm" x="73.4" y="21.65" size="2.1844" layer="27" display="off"/>
-<attribute name="DESCRIPTION" value="8-Bit Parallel-Load Shift Registers" x="73.4" y="21.65" size="2.1844" layer="27" display="off"/>
-<attribute name="NAME" x="73.45" y="15.7" size="1.27" layer="25" align="center"/>
-<attribute name="VALUE" x="74.15" y="21.75" size="0.9" layer="27" rot="R90" align="center"/>
+<element name="IC1" library="SamacSys_Parts" package="SOIC127P600X175-16N" value="SN74HC165DR" x="73.25" y="10.9" smashed="yes">
+<attribute name="DESCRIPTION" value="8-Bit Parallel-Load Shift Registers" x="73.25" y="10.9" size="2.1844" layer="27" display="off"/>
+<attribute name="HEIGHT" value="1.75mm" x="73.25" y="10.9" size="2.1844" layer="27" display="off"/>
+<attribute name="MANUFACTURER_NAME" value="Texas Instruments" x="73.25" y="10.9" size="2.1844" layer="27" display="off"/>
+<attribute name="MANUFACTURER_PART_NUMBER" value="SN74HC165DR" x="73.25" y="10.9" size="2.1844" layer="27" display="off"/>
+<attribute name="MOUSER_PART_NUMBER" value="595-SN74HC165DR" x="73.25" y="10.9" size="2.1844" layer="27" display="off"/>
+<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Texas-Instruments/SN74HC165DR?qs=vxEfx8VrU7AaZtng63yj8Q%3D%3D" x="73.25" y="10.9" size="2.1844" layer="27" display="off"/>
+<attribute name="NAME" x="73.25" y="5.2" size="0.8" layer="25" rot="R180" align="center"/>
+<attribute name="VALUE" x="74" y="11" size="0.9" layer="27" rot="R90" align="center"/>
 </element>
-<element name="IC2" library="SamacSys_Parts" package="SOIC127P600X175-16N" value="SN74HC165DR" x="73.4" y="32.45" smashed="yes">
-<attribute name="MOUSER_PART_NUMBER" value="595-SN74HC165DR" x="73.4" y="32.45" size="2.1844" layer="27" display="off"/>
-<attribute name="MANUFACTURER_PART_NUMBER" value="SN74HC165DR" x="73.4" y="32.45" size="2.1844" layer="27" display="off"/>
-<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Texas-Instruments/SN74HC165DR?qs=vxEfx8VrU7AaZtng63yj8Q%3D%3D" x="73.4" y="32.45" size="2.1844" layer="27" display="off"/>
-<attribute name="MANUFACTURER_NAME" value="Texas Instruments" x="73.4" y="32.45" size="2.1844" layer="27" display="off"/>
-<attribute name="HEIGHT" value="1.75mm" x="73.4" y="32.45" size="2.1844" layer="27" display="off"/>
-<attribute name="DESCRIPTION" value="8-Bit Parallel-Load Shift Registers" x="73.4" y="32.45" size="2.1844" layer="27" display="off"/>
-<attribute name="NAME" x="77.9" y="29.95" size="1.27" layer="25" rot="R270" align="center"/>
-<attribute name="VALUE" x="74.3" y="32.65" size="0.9" layer="27" rot="R90" align="center"/>
+<element name="IC2" library="SamacSys_Parts" package="SOIC127P600X175-16N" value="SN74HC165DR" x="73.25" y="22.55" smashed="yes">
+<attribute name="DESCRIPTION" value="8-Bit Parallel-Load Shift Registers" x="73.25" y="22.55" size="2.1844" layer="27" display="off"/>
+<attribute name="HEIGHT" value="1.75mm" x="73.25" y="22.55" size="2.1844" layer="27" display="off"/>
+<attribute name="MANUFACTURER_NAME" value="Texas Instruments" x="73.25" y="22.55" size="2.1844" layer="27" display="off"/>
+<attribute name="MANUFACTURER_PART_NUMBER" value="SN74HC165DR" x="73.25" y="22.55" size="2.1844" layer="27" display="off"/>
+<attribute name="MOUSER_PART_NUMBER" value="595-SN74HC165DR" x="73.25" y="22.55" size="2.1844" layer="27" display="off"/>
+<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Texas-Instruments/SN74HC165DR?qs=vxEfx8VrU7AaZtng63yj8Q%3D%3D" x="73.25" y="22.55" size="2.1844" layer="27" display="off"/>
+<attribute name="NAME" x="73.25" y="16.85" size="0.8" layer="25" rot="R180" align="center"/>
+<attribute name="VALUE" x="74.15" y="22.75" size="0.9" layer="27" rot="R90" align="center"/>
 </element>
-<element name="IC3" library="SamacSys_Parts" package="SOIC127P600X175-16N" value="SN74HC165DR" x="73.3" y="43.4" smashed="yes">
-<attribute name="MOUSER_PART_NUMBER" value="595-SN74HC165DR" x="73.3" y="43.4" size="2.1844" layer="27" display="off"/>
-<attribute name="MANUFACTURER_PART_NUMBER" value="SN74HC165DR" x="73.3" y="43.4" size="2.1844" layer="27" display="off"/>
-<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Texas-Instruments/SN74HC165DR?qs=vxEfx8VrU7AaZtng63yj8Q%3D%3D" x="73.3" y="43.4" size="2.1844" layer="27" display="off"/>
-<attribute name="MANUFACTURER_NAME" value="Texas Instruments" x="73.3" y="43.4" size="2.1844" layer="27" display="off"/>
-<attribute name="HEIGHT" value="1.75mm" x="73.3" y="43.4" size="2.1844" layer="27" display="off"/>
-<attribute name="DESCRIPTION" value="8-Bit Parallel-Load Shift Registers" x="73.3" y="43.4" size="2.1844" layer="27" display="off"/>
-<attribute name="NAME" x="73.55" y="49.5" size="1.27" layer="25" rot="R180" align="center"/>
-<attribute name="VALUE" x="74.15" y="43.4" size="0.9" layer="27" rot="R90" align="center"/>
+<element name="IC3" library="SamacSys_Parts" package="SOIC127P600X175-16N" value="SN74HC165DR" x="73.25" y="43.5" smashed="yes">
+<attribute name="DESCRIPTION" value="8-Bit Parallel-Load Shift Registers" x="73.25" y="43.5" size="2.1844" layer="27" display="off"/>
+<attribute name="HEIGHT" value="1.75mm" x="73.25" y="43.5" size="2.1844" layer="27" display="off"/>
+<attribute name="MANUFACTURER_NAME" value="Texas Instruments" x="73.25" y="43.5" size="2.1844" layer="27" display="off"/>
+<attribute name="MANUFACTURER_PART_NUMBER" value="SN74HC165DR" x="73.25" y="43.5" size="2.1844" layer="27" display="off"/>
+<attribute name="MOUSER_PART_NUMBER" value="595-SN74HC165DR" x="73.25" y="43.5" size="2.1844" layer="27" display="off"/>
+<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Texas-Instruments/SN74HC165DR?qs=vxEfx8VrU7AaZtng63yj8Q%3D%3D" x="73.25" y="43.5" size="2.1844" layer="27" display="off"/>
+<attribute name="NAME" x="73.25" y="37.8" size="0.8" layer="25" align="center"/>
+<attribute name="VALUE" x="74.1" y="43.5" size="0.9" layer="27" rot="R90" align="center"/>
 </element>
-<element name="RN1" library="SamacSys_Parts" package="EXBE10C103J" value="EXB-E10C103J" x="66.4" y="22.45" smashed="yes" rot="R90">
-<attribute name="MOUSER_PART_NUMBER" value="667-EXB-E10C103J" x="66.4" y="22.45" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="MANUFACTURER_PART_NUMBER" value="EXB-E10C103J" x="66.4" y="22.45" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Panasonic/EXB-E10C103J?qs=uA7cY%2Fh6FfVnJPppoc4q%2FQ%3D%3D" x="66.4" y="22.45" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="MANUFACTURER_NAME" value="Panasonic" x="66.4" y="22.45" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="HEIGHT" value="0.65mm" x="66.4" y="22.45" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="DESCRIPTION" value="PANASONIC - EXB-E10C103J - RESISTOR NETWORK, THICK FILM, 8, 10KOHM, 5%, 1608" x="66.4" y="22.45" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="NAME" x="66.45" y="18.35" size="1.27" layer="25" rot="R180" align="center"/>
+<element name="C3" library="rcl" library_urn="urn:adsk.eagle:library:334" package="C1206" package3d_urn="urn:adsk.eagle:package:23618/2" value="0.1uF" x="74.55" y="50.9" smashed="yes" rot="R180">
+<attribute name="NAME" x="74.583" y="52.44" size="0.8" layer="25" align="center"/>
+<attribute name="POPULARITY" value="24" x="74.55" y="50.9" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="SPICEPREFIX" value="C" x="74.55" y="50.9" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="VALUE" x="75.03" y="50.914" size="0.4" layer="27" rot="R270" align="top-center"/>
 </element>
-<element name="C3" library="rcl" package="C1206" value="0.1uF" x="79.05" y="46.45" smashed="yes" rot="R270">
-<attribute name="NAME" x="79.01" y="49.583" size="0.8" layer="25" align="center"/>
-<attribute name="VALUE" x="80.786" y="46.73" size="0.8" layer="27" rot="R90" align="center"/>
+<element name="IC6" library="SamacSys_Parts" package="SOP65P640X110-24N" value="PCA9555APW,118" x="73.05" y="33" smashed="yes">
+<attribute name="DESCRIPTION" value="NXP - PCA9555APW,118 - I/O EXPANDER, 16BIT, 400KHZ, TSSOP-24" x="73.05" y="33" size="0.6" layer="27" display="off"/>
+<attribute name="HEIGHT" value="1.1mm" x="73.05" y="33" size="0.6" layer="27" display="off"/>
+<attribute name="MANUFACTURER_NAME" value="NXP" x="73.05" y="33" size="0.6" layer="27" display="off"/>
+<attribute name="MANUFACTURER_PART_NUMBER" value="PCA9555APW,118" x="73.05" y="33" size="0.6" layer="27" display="off"/>
+<attribute name="MOUSER_PART_NUMBER" value="771-PCA9555APW118" x="73.05" y="33" size="0.6" layer="27" display="off"/>
+<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/NXP-Semiconductors/PCA9555APW118?qs=5C9Q4QJFsuPmpoGpn%2FKoIQ%3D%3D" x="73.05" y="33" size="0.6" layer="27" display="off"/>
+<attribute name="NAME" x="73.05" y="28.35" size="0.8" layer="25" rot="R180" align="center"/>
+<attribute name="VALUE" x="74.3" y="33.05" size="0.6" layer="27" rot="R90" align="center"/>
 </element>
-<element name="RN2" library="SamacSys_Parts" package="EXBE10C103J" value="EXB-E10C103J" x="66.4" y="32.9" smashed="yes" rot="R90">
-<attribute name="MOUSER_PART_NUMBER" value="667-EXB-E10C103J" x="66.4" y="32.9" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="MANUFACTURER_PART_NUMBER" value="EXB-E10C103J" x="66.4" y="32.9" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Panasonic/EXB-E10C103J?qs=uA7cY%2Fh6FfVnJPppoc4q%2FQ%3D%3D" x="66.4" y="32.9" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="MANUFACTURER_NAME" value="Panasonic" x="66.4" y="32.9" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="HEIGHT" value="0.65mm" x="66.4" y="32.9" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="DESCRIPTION" value="PANASONIC - EXB-E10C103J - RESISTOR NETWORK, THICK FILM, 8, 10KOHM, 5%, 1608" x="66.4" y="32.9" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="NAME" x="66.5" y="36.55" size="1.27" layer="25" rot="R180" align="center"/>
+<element name="C6" library="rcl" library_urn="urn:adsk.eagle:library:334" package="C1206" package3d_urn="urn:adsk.eagle:package:23618/2" value="0.1uF" x="79.3" y="35" smashed="yes" rot="R270">
+<attribute name="NAME" x="79.31" y="38.033" size="0.8" layer="25" align="center"/>
+<attribute name="POPULARITY" value="24" x="79.3" y="35" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="SPICEPREFIX" value="C" x="79.3" y="35" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="79.286" y="34.58" size="0.4" layer="27" rot="R180" align="top-center"/>
 </element>
-<element name="RN3" library="SamacSys_Parts" package="EXBE10C103J" value="EXB-E10C103J" x="66.4" y="44.25" smashed="yes" rot="R90">
-<attribute name="MOUSER_PART_NUMBER" value="667-EXB-E10C103J" x="66.4" y="44.25" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="MANUFACTURER_PART_NUMBER" value="EXB-E10C103J" x="66.4" y="44.25" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/Panasonic/EXB-E10C103J?qs=uA7cY%2Fh6FfVnJPppoc4q%2FQ%3D%3D" x="66.4" y="44.25" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="MANUFACTURER_NAME" value="Panasonic" x="66.4" y="44.25" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="HEIGHT" value="0.65mm" x="66.4" y="44.25" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="DESCRIPTION" value="PANASONIC - EXB-E10C103J - RESISTOR NETWORK, THICK FILM, 8, 10KOHM, 5%, 1608" x="66.4" y="44.25" size="0.9" layer="27" rot="R90" display="off"/>
-<attribute name="NAME" x="66.45" y="47.95" size="1.27" layer="25" align="center"/>
+<element name="R6" library="resistor" package="R1206" value="4k" x="12" y="11.6" smashed="yes">
+<attribute name="NAME" x="11.984" y="13.33" size="0.8" layer="25" rot="R180" align="center"/>
+<attribute name="VALUE" x="11.97" y="11.386" size="0.8" layer="27" rot="R180" align="center"/>
 </element>
-<element name="IC6" library="SamacSys_Parts" package="SOP65P640X110-24N" value="PCA9555APW,118" x="56.55" y="32.1" smashed="yes" rot="R270">
-<attribute name="DESCRIPTION" value="NXP - PCA9555APW,118 - I/O EXPANDER, 16BIT, 400KHZ, TSSOP-24" x="56.55" y="32.1" size="0.6" layer="27" rot="R270" display="off"/>
-<attribute name="MANUFACTURER_NAME" value="NXP" x="56.55" y="32.1" size="0.6" layer="27" rot="R270" display="off"/>
-<attribute name="MOUSER_PART_NUMBER" value="771-PCA9555APW118" x="56.55" y="32.1" size="0.6" layer="27" rot="R270" display="off"/>
-<attribute name="HEIGHT" value="1.1mm" x="56.55" y="32.1" size="0.6" layer="27" rot="R270" display="off"/>
-<attribute name="MOUSER_PRICE-STOCK" value="https://www.mouser.co.uk/ProductDetail/NXP-Semiconductors/PCA9555APW118?qs=5C9Q4QJFsuPmpoGpn%2FKoIQ%3D%3D" x="56.55" y="32.1" size="0.6" layer="27" rot="R270" display="off"/>
-<attribute name="MANUFACTURER_PART_NUMBER" value="PCA9555APW,118" x="56.55" y="32.1" size="0.6" layer="27" rot="R270" display="off"/>
-<attribute name="NAME" x="56.65" y="36.85" size="1.27" layer="25" align="center"/>
-<attribute name="VALUE" x="56.6" y="30.85" size="0.6" layer="27" align="center"/>
+<element name="R7" library="resistor" package="R1206" value="4k" x="18.95" y="11.6" smashed="yes" rot="R180">
+<attribute name="NAME" x="19.016" y="13.27" size="0.8" layer="25" align="center"/>
+<attribute name="VALUE" x="18.914" y="11.37" size="0.8" layer="27" align="center"/>
 </element>
-<element name="C6" library="rcl" package="C1206" value="0.1uF" x="63.2" y="27.25" smashed="yes">
-<attribute name="NAME" x="66.217" y="27.41" size="0.8" layer="25" rot="R90" align="center"/>
-<attribute name="VALUE" x="63.37" y="28.986" size="0.8" layer="27" rot="R180" align="center"/>
+<element name="RN4" library="resistor-net" library_urn="urn:adsk.eagle:library:343" package="CTS742C083" package3d_urn="urn:adsk.eagle:package:24985/1" value="CTS742C083" x="67" y="43.5" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="87.1" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="" x="87.1" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="67" y="41.528" size="0.6" layer="25" align="center"/>
+<attribute name="OC_FARNELL" value="unknown" x="87.1" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="OC_NEWARK" value="unknown" x="87.1" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="POPULARITY" value="0" x="87.1" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="67.006" y="42.228" size="0.3" layer="27" rot="R270" align="center-right"/>
 </element>
-<element name="R6" library="resistor" package="R1206" value="4k" x="5.6" y="11.15" smashed="yes" rot="R180">
-<attribute name="NAME" x="8.766" y="10.97" size="0.8" layer="25" rot="R270" align="center"/>
-<attribute name="VALUE" x="4.98" y="9.514" size="0.8" layer="27" align="center"/>
+<element name="RN6" library="resistor-net" library_urn="urn:adsk.eagle:library:343" package="CTS742C083" package3d_urn="urn:adsk.eagle:package:24985/1" value="CTS742C083" x="67" y="22.55" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="87.1" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="" x="87.1" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="66.974" y="20.578" size="0.6" layer="25" align="center"/>
+<attribute name="OC_FARNELL" value="unknown" x="87.1" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="OC_NEWARK" value="unknown" x="87.1" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="POPULARITY" value="0" x="87.1" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="67.006" y="21.278" size="0.3" layer="27" rot="R270" align="center-right"/>
 </element>
-<element name="R7" library="resistor" package="R1206" value="4k" x="21.25" y="12.35" smashed="yes" rot="R180">
-<attribute name="NAME" x="17.966" y="12.62" size="0.8" layer="25" rot="R270" align="center"/>
-<attribute name="VALUE" x="24.464" y="12.52" size="0.8" layer="27" rot="R270" align="center"/>
+<element name="RN8" library="resistor-net" library_urn="urn:adsk.eagle:library:343" package="CTS742C083" package3d_urn="urn:adsk.eagle:package:24985/1" value="CTS742C083" x="67" y="10.9" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="87.1" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="" x="87.1" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="67" y="8.928" size="0.6" layer="25" align="center"/>
+<attribute name="OC_FARNELL" value="unknown" x="87.1" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="OC_NEWARK" value="unknown" x="87.1" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="POPULARITY" value="0" x="87.1" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="67.006" y="9.628" size="0.3" layer="27" rot="R270" align="center-right"/>
+</element>
+<element name="RN1" library="resistor-net" library_urn="urn:adsk.eagle:library:343" package="CTS742C083" package3d_urn="urn:adsk.eagle:package:24985/1" value="CTS742C083" x="79.3" y="43.5" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="59.2" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="" x="59.2" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="79.374" y="41.528" size="0.6" layer="25" align="center"/>
+<attribute name="OC_FARNELL" value="unknown" x="59.2" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="OC_NEWARK" value="unknown" x="59.2" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="POPULARITY" value="0" x="59.2" y="43.5" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="79.306" y="42.278" size="0.3" layer="27" rot="R270" align="center-right"/>
+</element>
+<element name="RN2" library="resistor-net" library_urn="urn:adsk.eagle:library:343" package="CTS742C083" package3d_urn="urn:adsk.eagle:package:24985/1" value="CTS742C083" x="79.3" y="22.55" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="59.2" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="" x="59.2" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="79.3" y="20.578" size="0.6" layer="25" align="center"/>
+<attribute name="OC_FARNELL" value="unknown" x="59.2" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="OC_NEWARK" value="unknown" x="59.2" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="POPULARITY" value="0" x="59.2" y="22.55" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="79.306" y="21.278" size="0.3" layer="27" rot="R270" align="center-right"/>
+</element>
+<element name="RN3" library="resistor-net" library_urn="urn:adsk.eagle:library:343" package="CTS742C083" package3d_urn="urn:adsk.eagle:package:24985/1" value="CTS742C083" x="79.3" y="10.9" smashed="yes" rot="R270">
+<attribute name="MF" value="" x="59.2" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="MPN" value="" x="59.2" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="79.3" y="8.928" size="0.6" layer="25" align="center"/>
+<attribute name="OC_FARNELL" value="unknown" x="59.2" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="OC_NEWARK" value="unknown" x="59.2" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="POPULARITY" value="0" x="59.2" y="10.9" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="VALUE" x="79.306" y="9.678" size="0.3" layer="27" rot="R270" align="center-right"/>
 </element>
 </elements>
 <signals>
@@ -3397,24 +3552,23 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 </polygon>
 <contactref element="SW1" pad="C"/>
 <contactref element="SW1" pad="D"/>
-<wire x1="11.45" y1="5.4" x2="11.5" y2="5.3" width="0.3" layer="1"/>
-<wire x1="9.75" y1="6.52" x2="9.12" y2="6.52" width="0.3" layer="1"/>
-<wire x1="9.12" y1="6.52" x2="8.85" y2="6.25" width="0.3" layer="1"/>
-<wire x1="12.15" y1="8.02" x2="13.23" y2="8.02" width="0.3" layer="1"/>
-<wire x1="13.23" y1="8.02" x2="13.3" y2="8.1" width="0.3" layer="1"/>
-<via x="11.5" y="5.3" extent="1-16" drill="0.35"/>
-<via x="13.3" y="8.1" extent="1-16" drill="0.35"/>
-<via x="13.3" y="6.65" extent="1-16" drill="0.35"/>
-<via x="19.3" y="6.5" extent="1-16" drill="0.3"/>
-<via x="3.3" y="7.1" extent="1-16" drill="0.3"/>
+<wire x1="7.175" y1="5.745" x2="6.47" y2="5.745" width="0.3" layer="1"/>
+<wire x1="6.47" y1="5.745" x2="6.15" y2="5.425" width="0.3" layer="1"/>
+<wire x1="10.325" y1="7.595" x2="9.975" y2="7.245" width="0.3" layer="1"/>
+<wire x1="9.575" y1="7.245" x2="9.975" y2="7.245" width="0.3" layer="1"/>
+<wire x1="10.25" y1="9.15" x2="10.325" y2="9.075" width="0.3" layer="1"/>
+<wire x1="10.325" y1="9.075" x2="10.325" y2="7.595" width="0.3" layer="1"/>
+<via x="8.675" y="4.6" extent="1-16" drill="0.45"/>
+<via x="10.25" y="9.15" extent="1-16" drill="0.45"/>
+<via x="10.575" y="5.75" extent="1-16" drill="0.45"/>
 <contactref element="IC4" pad="7"/>
-<wire x1="10.95" y1="6.32" x2="10.95" y2="5.9" width="0.3" layer="1"/>
-<wire x1="10.95" y1="5.9" x2="11.5" y2="5.3" width="0.3" layer="1"/>
+<wire x1="8.375" y1="5.545" x2="8.375" y2="4.9" width="0.3" layer="1"/>
+<wire x1="8.675" y1="4.6" x2="8.375" y2="4.9" width="0.3" layer="1"/>
 <contactref element="IC5" pad="3"/>
 <contactref element="IC5" pad="1"/>
 <contactref element="C5" pad="2"/>
 <contactref element="R4" pad="1"/>
-<via x="8.85" y="6.25" extent="1-16" drill="0.35"/>
+<via x="6.15" y="5.425" extent="1-16" drill="0.45"/>
 <contactref element="IC1" pad="8"/>
 <contactref element="IC3" pad="8"/>
 <contactref element="IC2" pad="8"/>
@@ -3422,177 +3576,150 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 <contactref element="IC3" pad="15"/>
 <contactref element="IC1" pad="15"/>
 <contactref element="C3" pad="2"/>
-<wire x1="76.012" y1="46.575" x2="77.125" y2="46.575" width="0.5" layer="1"/>
-<wire x1="77.125" y1="46.575" x2="77.25" y2="46.45" width="0.5" layer="1"/>
-<wire x1="76.112" y1="35.625" x2="76.925" y2="35.625" width="0.5" layer="1"/>
-<wire x1="76.925" y1="35.625" x2="77.3" y2="35.25" width="0.5" layer="1"/>
-<wire x1="76.112" y1="24.825" x2="76.975" y2="24.825" width="0.5" layer="1"/>
-<wire x1="76.975" y1="24.825" x2="77.3" y2="24.5" width="0.5" layer="1"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GND@5"/>
 <contactref element="C6" pad="2"/>
 <contactref element="IC6" pad="2"/>
 <contactref element="IC6" pad="3"/>
 <contactref element="IC6" pad="12"/>
 <contactref element="IC6" pad="21"/>
-<wire x1="58.825" y1="35.038" x2="58.825" y2="33.95" width="0.4" layer="1"/>
-<wire x1="59.475" y1="35.038" x2="59.475" y2="33.85" width="0.4" layer="1"/>
-<wire x1="52.975" y1="35.038" x2="52.975" y2="33.625" width="0.4" layer="1"/>
-<wire x1="58.175" y1="29.725" x2="58.175" y2="30.425" width="0.4" layer="1"/>
-<wire x1="58.175" y1="30.425" x2="58.2" y2="30.45" width="0.4" layer="1"/>
-<via x="69.3" y="28.05" extent="1-16" drill="0.45"/>
-<via x="65.35" y="28.8" extent="1-16" drill="0.45"/>
-<via x="69.1" y="38.95" extent="1-16" drill="0.45"/>
-<via x="69.1" y="17.3" extent="1-16" drill="0.45"/>
-<wire x1="70.688" y1="17.205" x2="69.195" y2="17.205" width="0.4" layer="1"/>
-<wire x1="69.195" y1="17.205" x2="69.1" y2="17.3" width="0.4" layer="1"/>
-<wire x1="70.688" y1="28.005" x2="69.345" y2="28.005" width="0.4" layer="1"/>
-<wire x1="69.345" y1="28.005" x2="69.3" y2="28.05" width="0.4" layer="1"/>
-<wire x1="70.588" y1="38.955" x2="69.105" y2="38.955" width="0.4" layer="1"/>
-<wire x1="69.105" y1="38.955" x2="69.1" y2="38.95" width="0.4" layer="1"/>
+<via x="69.25" y="18.05" extent="1-16" drill="0.45"/>
 <contactref element="IC3" pad="10"/>
-<wire x1="52.975" y1="33.625" x2="53.4" y2="33.2" width="0.4" layer="1"/>
-<wire x1="53.4" y1="33.2" x2="58.075" y2="33.2" width="0.4" layer="1"/>
-<wire x1="58.075" y1="33.2" x2="58.688875" y2="33.813875" width="0.4" layer="1"/>
-<wire x1="58.688875" y1="33.813875" x2="58.825" y2="33.95" width="0.4" layer="1"/>
-<wire x1="58.688875" y1="33.813875" x2="59.438875" y2="33.813875" width="0.4" layer="1"/>
-<wire x1="59.438875" y1="33.813875" x2="59.475" y2="33.85" width="0.4" layer="1"/>
-<via x="54.85" y="41.55" extent="1-16" drill="0.35"/>
-<wire x1="58.175" y1="30.425" x2="58.175" y2="33.1" width="0.4" layer="1"/>
-<wire x1="58.175" y1="33.1" x2="58.075" y2="33.2" width="0.4" layer="1"/>
-<via x="58.15" y="30.45" extent="1-16" drill="0.45"/>
-<wire x1="58.175" y1="29.162" x2="58.175" y2="29.725" width="0.4" layer="1"/>
-<wire x1="58.175" y1="29.725" x2="58.15" y2="30.45" width="0.4" layer="1"/>
-<via x="47.9" y="26.1" extent="1-16" drill="0.45"/>
-<via x="53" y="27.9" extent="1-16" drill="0.35"/>
-<via x="44.4" y="25.55" extent="1-16" drill="0.45"/>
-<via x="56.25" y="27.05" extent="1-16" drill="0.35"/>
-<via x="37.9" y="25.15" extent="1-16" drill="0.45"/>
-<via x="42.3" y="24.65" extent="1-16" drill="0.45"/>
-<via x="45.1" y="27.7" extent="1-16" drill="0.45"/>
-<via x="64.45" y="13.7" extent="1-16" drill="0.45"/>
-<via x="57.1" y="11.4" extent="1-16" drill="0.45"/>
-<via x="65.9" y="17.2" extent="1-16" drill="0.35"/>
-<via x="58.95" y="21.4" extent="1-16" drill="0.35"/>
-<via x="62.5" y="24.7" extent="1-16" drill="0.3"/>
-<via x="55.85" y="20.05" extent="1-16" drill="0.35"/>
-<via x="68.9" y="6.15" extent="1-16" drill="0.45"/>
-<via x="78.8" y="10.95" extent="1-16" drill="0.45"/>
-<via x="14.65" y="10.4" extent="1-16" drill="0.3"/>
-<via x="19.55" y="14.5" extent="1-16" drill="0.3"/>
-<via x="58.8" y="40.9" extent="1-16" drill="0.35"/>
-<via x="65.45" y="38.4" extent="1-16" drill="0.35"/>
-<via x="65.2" y="39.55" extent="1-16" drill="0.3"/>
-<wire x1="12.15" y1="7.02" x2="12.93" y2="7.02" width="0.3" layer="1"/>
-<wire x1="12.93" y1="7.02" x2="13.3" y2="6.65" width="0.3" layer="1"/>
-<via x="60.5" y="8.1" extent="1-16" drill="0.45"/>
-<via x="60.4" y="22.65" extent="1-16" drill="0.3"/>
-<via x="56.3" y="15.1" extent="1-16" drill="0.45"/>
-<via x="77.35" y="40.2" extent="1-16" drill="0.35"/>
-<via x="79" y="32.6" extent="1-16" drill="0.35"/>
-<via x="78.85" y="21.85" extent="1-16" drill="0.35"/>
-<via x="36.2" y="42.1" extent="1-16" drill="0.35"/>
-<via x="62.35" y="37.95" extent="1-16" drill="0.35"/>
-<via x="59.8" y="38.9" extent="1-16" drill="0.35"/>
-<wire x1="59.475" y1="35.038" x2="59.475" y2="36.475" width="0.4" layer="1"/>
-<wire x1="58.825" y1="35.038" x2="58.825" y2="36.575" width="0.4" layer="1"/>
-<via x="14.7" y="19.55" extent="1-16" drill="0.45"/>
-<via x="9.3" y="12.55" extent="1-16" drill="0.45"/>
-<via x="37.35" y="39.15" extent="1-16" drill="0.35"/>
-<via x="16.6" y="38.45" extent="1-16" drill="0.35"/>
+<via x="68.575" y="48.4" extent="1-16" drill="0.45"/>
+<via x="59" y="27.9" extent="1-16" drill="0.45"/>
+<via x="53.675" y="27.425" extent="1-16" drill="0.45"/>
+<via x="40.15" y="24.725" extent="1-16" drill="0.45"/>
+<via x="68.75" y="29.4" extent="1-16" drill="0.45"/>
+<via x="46.3" y="24.95" extent="1-16" drill="0.45"/>
+<via x="47.38125" y="28.81875" extent="1-16" drill="0.45"/>
+<via x="74.3" y="14.15" extent="1-16" drill="0.45"/>
+<via x="62.8" y="25.55" extent="1-16" drill="0.45"/>
+<via x="65.05" y="17.7" extent="1-16" drill="0.45"/>
+<via x="57.15" y="20.2" extent="1-16" drill="0.45"/>
+<via x="67.475" y="17.75" extent="1-16" drill="0.45"/>
+<via x="69.15" y="6.45" extent="1-16" drill="0.45"/>
+<via x="73.775" y="6.9" extent="1-16" drill="0.45"/>
+<via x="15.4" y="11.525" extent="1-16" drill="0.45"/>
+<via x="65.1" y="51.9" extent="1-16" drill="0.45"/>
+<wire x1="9.575" y1="6.245" x2="10.08" y2="6.245" width="0.3" layer="1"/>
+<wire x1="10.08" y1="6.245" x2="10.575" y2="5.75" width="0.3" layer="1"/>
+<via x="61.55" y="16.15" extent="1-16" drill="0.45"/>
+<via x="33" y="29.25" extent="1-16" drill="0.45"/>
+<via x="61.65" y="28.5" extent="1-16" drill="0.45"/>
+<via x="79.3" y="46.55" extent="1-16" drill="0.45"/>
+<via x="75.95" y="28.3" extent="1-16" drill="0.45"/>
+<via x="79.3" y="19.55" extent="1-16" drill="0.45"/>
+<via x="79.3" y="31.75" extent="1-16" drill="0.45"/>
+<via x="13.45" y="9.225" extent="1-16" drill="0.45"/>
+<via x="11.75" y="2.825" extent="1-16" drill="0.45"/>
+<via x="18.8" y="5.325" extent="1-16" drill="0.45"/>
+<via x="23.3" y="8.775" extent="1-16" drill="0.45"/>
+<via x="17.65" y="2.975" extent="1-16" drill="0.45"/>
+<via x="71.8" y="35.9" extent="1-16" drill="0.45"/>
+<via x="77.65" y="35" extent="1-16" drill="0.45"/>
+<via x="74.35" y="25.7" extent="1-16" drill="0.45"/>
+<via x="45.7" y="21" extent="1-16" drill="0.45"/>
+<via x="26.95" y="10.525" extent="1-16" drill="0.45"/>
+<via x="68.95" y="39.05" extent="1-16" drill="0.45"/>
+<via x="54.95" y="10.15" extent="1-16" drill="0.45"/>
+<wire x1="70.112" y1="35.925" x2="71.775" y2="35.925" width="0.3" layer="1"/>
+<wire x1="71.775" y1="35.925" x2="71.8" y2="35.9" width="0.3" layer="1"/>
+<via x="2.2" y="11.625" extent="1-16" drill="0.45"/>
+<via x="73.2" y="52.35" extent="1-16" drill="0.45"/>
+<via x="75.95" y="16.65" extent="1-16" drill="0.45"/>
 </signal>
 <signal name="SDA">
 <contactref element="IC4" pad="6"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP4"/>
 <contactref element="IC5" pad="9"/>
-<wire x1="71.65" y1="11.15" x2="70.05" y2="11.15" width="0.3" layer="1"/>
 <contactref element="IC6" pad="23"/>
-<wire x1="14.51" y1="16.595" x2="14.51" y2="14.95" width="0.3" layer="1"/>
 <contactref element="R6" pad="2"/>
-<wire x1="14.51" y1="16.595" x2="14.51" y2="18.26" width="0.3" layer="1"/>
-<via x="38.7" y="26.5" extent="1-16" drill="0.35"/>
-<wire x1="22.45" y1="26.2" x2="38.4" y2="26.2" width="0.3" layer="1"/>
-<wire x1="38.4" y1="26.2" x2="38.7" y2="26.5" width="0.3" layer="1"/>
-<wire x1="38.7" y1="26.5" x2="42.5" y2="26.5" width="0.3" layer="16"/>
-<wire x1="46.6" y1="22.4" x2="55" y2="22.4" width="0.3" layer="16"/>
-<wire x1="55" y1="22.4" x2="58.95" y2="26.35" width="0.3" layer="16"/>
-<via x="55" y="22.4" extent="1-16" drill="0.35"/>
-<wire x1="55" y1="14.1" x2="56.6" y2="12.5" width="0.3" layer="1"/>
-<wire x1="56.6" y1="12.5" x2="68.7" y2="12.5" width="0.3" layer="1"/>
-<wire x1="10.45" y1="6.32" x2="10.45" y2="5.4" width="0.3" layer="1"/>
-<wire x1="10.45" y1="5.4" x2="10.55" y2="5.3" width="0.3" layer="1"/>
-<via x="10.55" y="5.3" extent="1-16" drill="0.35"/>
-<wire x1="10.55" y1="5.3" x2="10.55" y2="10.55" width="0.3" layer="16"/>
-<via x="10.55" y="10.55" extent="1-16" drill="0.35"/>
-<wire x1="4.178" y1="11.15" x2="4.178" y2="12.978" width="0.3" layer="1"/>
-<wire x1="4.178" y1="12.978" x2="5.4" y2="14.2" width="0.3" layer="1"/>
-<wire x1="5.4" y1="14.2" x2="12" y2="14.2" width="0.3" layer="1"/>
-<wire x1="12" y1="14.2" x2="13.76" y2="14.2" width="0.3" layer="1"/>
-<wire x1="13.76" y1="14.2" x2="14.51" y2="14.95" width="0.3" layer="1"/>
-<wire x1="10.55" y1="10.55" x2="10.55" y2="12.75" width="0.3" layer="1"/>
-<wire x1="10.55" y1="12.75" x2="12" y2="14.2" width="0.3" layer="1"/>
-<wire x1="59.475" y1="29.162" x2="59.475" y2="26.875" width="0.3" layer="1"/>
-<wire x1="59.475" y1="26.875" x2="58.95" y2="26.35" width="0.3" layer="1"/>
-<via x="58.95" y="26.35" extent="1-16" drill="0.3"/>
-<wire x1="55" y1="22.4" x2="55" y2="14.1" width="0.3" layer="1"/>
-<wire x1="22.45" y1="26.2" x2="14.51" y2="18.26" width="0.3" layer="1"/>
-<wire x1="42.5" y1="26.5" x2="46.6" y2="22.4" width="0.3" layer="16"/>
-<wire x1="68.7" y1="12.5" x2="70.05" y2="11.15" width="0.3" layer="1"/>
+<wire x1="15.01" y1="17.23" x2="15.01" y2="17.26" width="0.3" layer="1"/>
+<wire x1="15.01" y1="17.26" x2="20.975" y2="23.225" width="0.3" layer="1"/>
+<via x="47.475" y="23.225" extent="1-16" drill="0.45"/>
+<wire x1="20.975" y1="23.225" x2="47.475" y2="23.225" width="0.3" layer="1"/>
+<wire x1="49.25" y1="21.45" x2="56" y2="21.45" width="0.3" layer="16"/>
+<wire x1="7.875" y1="5.545" x2="7.875" y2="4.425" width="0.3" layer="1"/>
+<wire x1="49.25" y1="21.45" x2="47.475" y2="23.225" width="0.3" layer="16"/>
+<wire x1="7.875" y1="4.425" x2="8.375" y2="3.925" width="0.3" layer="1"/>
+<wire x1="8.375" y1="3.925" x2="10.125" y2="3.925" width="0.3" layer="1"/>
+<wire x1="15.01" y1="17.23" x2="14.983328125" y2="17.203328125" width="0.3" layer="1"/>
+<wire x1="14.983328125" y1="13.161328125" x2="13.436" y2="11.614" width="0.3" layer="1"/>
+<wire x1="13.436" y1="11.614" x2="13.422" y2="11.6" width="0.3" layer="1"/>
+<wire x1="14.983328125" y1="17.203328125" x2="14.983328125" y2="13.161328125" width="0.3" layer="1"/>
+<wire x1="17.3" y1="7.25" x2="16.4" y2="7.25" width="0.3" layer="1"/>
+<wire x1="13.436" y1="10.214" x2="13.436" y2="11.614" width="0.3" layer="1"/>
+<wire x1="16.4" y1="7.25" x2="13.436" y2="10.214" width="0.3" layer="1"/>
+<wire x1="73.5" y1="30" x2="73.5" y2="35.45" width="0.3" layer="16"/>
+<wire x1="73.5" y1="35.45" x2="73.9794" y2="35.9294" width="0.3" layer="16"/>
+<wire x1="73.9794" y1="35.9294" x2="74.4282" y2="35.9294" width="0.3" layer="16"/>
+<via x="74.4282" y="35.9294" extent="1-16" drill="0.45"/>
+<wire x1="74.4282" y1="35.9294" x2="74.4326" y2="35.925" width="0.3" layer="1"/>
+<wire x1="74.4326" y1="35.925" x2="75.988" y2="35.925" width="0.3" layer="1"/>
+<wire x1="56" y1="21.45" x2="61.65" y2="27.1" width="0.3" layer="16"/>
+<wire x1="61.65" y1="27.1" x2="70.6" y2="27.1" width="0.3" layer="16"/>
+<wire x1="70.6" y1="27.1" x2="73.5" y2="30" width="0.3" layer="16"/>
+<wire x1="11.3" y1="8.078" x2="13.436" y2="10.214" width="0.3" layer="1"/>
+<wire x1="10.125" y1="3.925" x2="11.3" y2="5.1" width="0.3" layer="1"/>
+<wire x1="11.3" y1="5.1" x2="11.3" y2="8.078" width="0.3" layer="1"/>
 </signal>
 <signal name="SCL">
 <contactref element="IC4" pad="4"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP5"/>
 <contactref element="IC5" pad="10"/>
-<wire x1="71.65" y1="11.65" x2="71.65" y2="13.05" width="0.3" layer="1"/>
 <contactref element="IC6" pad="22"/>
-<wire x1="17.05" y1="16.595" x2="17.05" y2="14.25" width="0.3" layer="1"/>
 <contactref element="R7" pad="2"/>
-<wire x1="19.828" y1="12.35" x2="18.95" y2="12.35" width="0.4" layer="1"/>
-<wire x1="18.95" y1="12.35" x2="17.05" y2="14.25" width="0.3" layer="1"/>
-<wire x1="55.45" y1="24.05" x2="46.95" y2="24.05" width="0.3" layer="16"/>
-<via x="35.95" y="24.95" extent="1-16" drill="0.35"/>
-<wire x1="38.55" y1="27.55" x2="43.45" y2="27.55" width="0.3" layer="16"/>
-<wire x1="43.45" y1="27.55" x2="46.95" y2="24.05" width="0.3" layer="16"/>
-<wire x1="9.75" y1="7.02" x2="8.67" y2="7.02" width="0.3" layer="1"/>
-<wire x1="8.67" y1="7.02" x2="8.15" y2="6.5" width="0.3" layer="1"/>
-<wire x1="8.15" y1="6.5" x2="8.15" y2="5" width="0.3" layer="1"/>
-<wire x1="8.15" y1="5" x2="8.7" y2="4.45" width="0.3" layer="1"/>
-<wire x1="8.7" y1="4.45" x2="13.45" y2="4.45" width="0.3" layer="1"/>
-<wire x1="13.45" y1="4.45" x2="17.05" y2="8.05" width="0.3" layer="1"/>
-<wire x1="58.825" y1="29.162" x2="58.825" y2="27.425" width="0.3" layer="1"/>
-<wire x1="58.825" y1="27.425" x2="57.85" y2="26.45" width="0.3" layer="1"/>
-<via x="57.85" y="26.45" extent="1-16" drill="0.3"/>
-<wire x1="57.85" y1="26.45" x2="55.45" y2="24.05" width="0.3" layer="16"/>
-<via x="55.45" y="24.05" extent="1-16" drill="0.3"/>
-<wire x1="56.7" y1="16" x2="56.7" y2="22.8" width="0.3" layer="1"/>
-<wire x1="56.7" y1="22.8" x2="55.45" y2="24.05" width="0.3" layer="1"/>
-<wire x1="56.7" y1="16" x2="57.75" y2="14.95" width="0.3" layer="1"/>
-<wire x1="57.75" y1="14.95" x2="69.75" y2="14.95" width="0.3" layer="1"/>
-<wire x1="38.55" y1="27.55" x2="35.95" y2="24.95" width="0.3" layer="16"/>
-<wire x1="35.95" y1="24.95" x2="24.2" y2="24.95" width="0.3" layer="1"/>
-<wire x1="24.2" y1="24.95" x2="16.95" y2="17.7" width="0.3" layer="1"/>
-<wire x1="17.05" y1="16.595" x2="16.95" y2="17.7" width="0.3" layer="1"/>
-<wire x1="69.75" y1="14.95" x2="71.65" y2="13.05" width="0.3" layer="1"/>
-<wire x1="17.05" y1="14.25" x2="17.05" y2="8.05" width="0.3" layer="1"/>
+<wire x1="17.528" y1="11.6" x2="17.575" y2="11.647" width="0.4" layer="1"/>
+<wire x1="17.55" y1="17.23" x2="17.55" y2="17.4" width="0.3" layer="1"/>
+<wire x1="17.55" y1="17.4" x2="22.675" y2="22.525" width="0.3" layer="1"/>
+<wire x1="46.75" y1="22.525" x2="22.675" y2="22.525" width="0.3" layer="1"/>
+<via x="46.75" y="22.525" extent="1-16" drill="0.45"/>
+<wire x1="17.55" y1="17.23" x2="17.575" y2="17.205" width="0.4" layer="1"/>
+<wire x1="17.575" y1="17.205" x2="17.575" y2="11.647" width="0.4" layer="1"/>
+<wire x1="46.75" y1="22.525" x2="47.225" y2="22.525" width="0.3" layer="16"/>
+<wire x1="47.225" y1="22.525" x2="48.85" y2="20.9" width="0.3" layer="16"/>
+<wire x1="48.85" y1="20.9" x2="56.4823" y2="20.9" width="0.3" layer="16"/>
+<wire x1="61.9823" y1="26.4" x2="70.85" y2="26.4" width="0.3" layer="16"/>
+<wire x1="70.85" y1="26.4" x2="74.1" y2="29.65" width="0.3" layer="16"/>
+<wire x1="74.1" y1="34.6" x2="74.8" y2="35.3" width="0.3" layer="16"/>
+<via x="74.8" y="35.3" extent="1-16" drill="0.45"/>
+<wire x1="74.8" y1="35.3" x2="75.963" y2="35.3" width="0.3" layer="1"/>
+<wire x1="75.963" y1="35.3" x2="75.988" y2="35.275" width="0.3" layer="1"/>
+<wire x1="56.4823" y1="20.9" x2="61.9823" y2="26.4" width="0.3" layer="16"/>
+<wire x1="74.1" y1="29.65" x2="74.1" y2="34.6" width="0.3" layer="16"/>
+<wire x1="17.575" y1="10.55" x2="17.575" y2="11.553" width="0.3" layer="1"/>
+<wire x1="17.575" y1="11.553" x2="17.528" y2="11.6" width="0.3" layer="1"/>
+<wire x1="17.3" y1="7.75" x2="17.3" y2="10.275" width="0.3" layer="1"/>
+<wire x1="17.3" y1="10.275" x2="17.3" y2="10.3" width="0.3" layer="1"/>
+<wire x1="17.3" y1="10.275" x2="17.575" y2="10.55" width="0.3" layer="1"/>
+<wire x1="7.175" y1="6.245" x2="6.405" y2="6.245" width="0.3" layer="1"/>
+<wire x1="6.405" y1="6.245" x2="6.15" y2="6.5" width="0.3" layer="1"/>
+<via x="6.15" y="6.5" extent="1-16" drill="0.45"/>
+<wire x1="6.15" y1="6.5" x2="7.95" y2="8.3" width="0.3" layer="16"/>
+<wire x1="15.3" y1="8.3" x2="16.6" y2="9.6" width="0.3" layer="16"/>
+<via x="16.6" y="9.6" extent="1-16" drill="0.45"/>
+<wire x1="16.6" y1="9.6" x2="17.3" y2="10.3" width="0.3" layer="1"/>
+<wire x1="7.95" y1="8.3" x2="15.3" y2="8.3" width="0.3" layer="16"/>
 </signal>
 <signal name="ACCEL_INTR">
 <contactref element="IC4" pad="11"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP14"/>
-<wire x1="47.53" y1="16.595" x2="47.53" y2="18.08" width="0.4" layer="1"/>
-<via x="15.75" y="9.25" extent="1-16" drill="0.35"/>
-<via x="23.75" y="9.25" extent="1-16" drill="0.35"/>
-<wire x1="26.7" y1="9.25" x2="27.75" y2="10.3" width="0.3" layer="1"/>
-<wire x1="27.75" y1="10.3" x2="45.25" y2="10.3" width="0.3" layer="1"/>
-<via x="45.25" y="10.3" extent="1-16" drill="0.35"/>
-<wire x1="45.25" y1="10.3" x2="46.25" y2="10.3" width="0.3" layer="16"/>
-<wire x1="46.25" y1="10.3" x2="47.65" y2="11.7" width="0.3" layer="16"/>
-<wire x1="47.65" y1="11.7" x2="47.65" y2="14.45" width="0.3" layer="16"/>
-<via x="47.65" y="14.45" extent="1-16" drill="0.35"/>
-<wire x1="47.53" y1="16.595" x2="47.53" y2="14.57" width="0.3" layer="1"/>
-<wire x1="47.53" y1="14.57" x2="47.65" y2="14.45" width="0.3" layer="1"/>
-<wire x1="12.15" y1="7.52" x2="14.02" y2="7.52" width="0.3" layer="1"/>
-<wire x1="23.75" y1="9.25" x2="15.75" y2="9.25" width="0.3" layer="16"/>
-<wire x1="14.02" y1="7.52" x2="15.75" y2="9.25" width="0.3" layer="1"/>
-<wire x1="23.75" y1="9.25" x2="26.7" y2="9.25" width="0.3" layer="1"/>
+<via x="10.575" y="6.725" extent="1-16" drill="0.45"/>
+<via x="30.175" y="8.35" extent="1-16" drill="0.45"/>
+<via x="43.925" y="8.3" extent="1-16" drill="0.45"/>
+<wire x1="54.225" y1="8.45" x2="44.075" y2="8.45" width="0.3" layer="16"/>
+<wire x1="44.075" y1="8.45" x2="43.925" y2="8.3" width="0.3" layer="16"/>
+<via x="54.225" y="8.45" extent="1-16" drill="0.45"/>
+<wire x1="54.225" y1="8.45" x2="48.03" y2="14.645" width="0.4" layer="1"/>
+<wire x1="48.03" y1="17.23" x2="48.03" y2="14.645" width="0.3" layer="1"/>
+<wire x1="10.575" y1="6.725" x2="10.555" y2="6.745" width="0.3" layer="1"/>
+<wire x1="10.555" y1="6.745" x2="9.575" y2="6.745" width="0.3" layer="1"/>
+<wire x1="30.175" y1="8.35" x2="30.125" y2="8.3" width="0.3" layer="16"/>
+<wire x1="30.125" y1="8.3" x2="25.725" y2="8.3" width="0.3" layer="16"/>
+<wire x1="25.725" y1="8.3" x2="24.375" y2="6.95" width="0.3" layer="16"/>
+<wire x1="24.375" y1="6.95" x2="10.8" y2="6.95" width="0.3" layer="16"/>
+<wire x1="10.8" y1="6.95" x2="10.575" y2="6.725" width="0.3" layer="16"/>
+<wire x1="43.925" y1="8.3" x2="30.225" y2="8.3" width="0.3" layer="1"/>
+<wire x1="30.225" y1="8.3" x2="30.175" y2="8.35" width="0.3" layer="1"/>
 </signal>
 <signal name="3V3_PICO">
 <contactref element="IC4" pad="1"/>
@@ -3607,15 +3734,11 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 <wire x1="29.75" y1="2.84" x2="29.75" y2="2.15" width="1" layer="1"/>
 <wire x1="34.83" y1="2.84" x2="34.83" y2="2.13" width="1" layer="1"/>
 <wire x1="33.85" y1="1.15" x2="31" y2="1.15" width="1" layer="1"/>
-<wire x1="11.97" y1="35.645" x2="11.97" y2="38.73" width="1" layer="1"/>
-<wire x1="11.97" y1="38.73" x2="9.7" y2="41" width="1" layer="1"/>
+<wire x1="12.47" y1="35.01" x2="12.47" y2="38.23" width="1" layer="1"/>
+<wire x1="12.47" y1="38.23" x2="9.7" y2="41" width="1" layer="1"/>
 <contactref element="IC5" pad="8"/>
 <contactref element="C5" pad="1"/>
 <contactref element="R5" pad="1"/>
-<wire x1="71.65" y1="10.65" x2="73.4" y2="10.65" width="0.3" layer="1"/>
-<wire x1="73.4" y1="10.65" x2="74.3" y2="11.55" width="0.3" layer="1"/>
-<wire x1="74.3" y1="11.55" x2="74.3" y2="11.9" width="0.3" layer="1"/>
-<wire x1="74.3" y1="11.55" x2="74.3" y2="11.2" width="0.3" layer="1"/>
 <wire x1="9.7" y1="41" x2="3.15" y2="41" width="1" layer="1"/>
 <wire x1="3.15" y1="41" x2="1" y2="43.15" width="1" layer="1"/>
 <wire x1="1" y1="44.975" x2="1" y2="43.15" width="1" layer="1"/>
@@ -3624,670 +3747,713 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 <contactref element="IC2" pad="16"/>
 <contactref element="C3" pad="1"/>
 <contactref element="IC3" pad="16"/>
-<wire x1="76.112" y1="26.095" x2="76.045" y2="26.145" width="0.5" layer="1"/>
 <contactref element="C6" pad="1"/>
 <contactref element="IC6" pad="24"/>
-<wire x1="76.012" y1="47.845" x2="79.045" y2="47.845" width="0.6" layer="1"/>
-<wire x1="79.045" y1="47.845" x2="79.05" y2="47.85" width="0.6" layer="1"/>
-<wire x1="76.112" y1="36.895" x2="78.975" y2="36.895" width="0.6" layer="1"/>
-<wire x1="78.975" y1="36.895" x2="79.05" y2="36.97" width="0.6" layer="1"/>
-<wire x1="76.112" y1="26.095" x2="78.845" y2="26.095" width="0.6" layer="1"/>
-<wire x1="78.845" y1="26.095" x2="78.95" y2="26.2" width="0.6" layer="1"/>
-<wire x1="74.3" y1="11.9" x2="74.3" y2="13.7" width="1" layer="1"/>
-<wire x1="74.3" y1="13.7" x2="75.6" y2="15" width="1" layer="1"/>
-<wire x1="75.6" y1="15" x2="79.5" y2="15" width="1" layer="1"/>
-<wire x1="81.15" y1="7.3" x2="81.15" y2="13.35" width="1" layer="1"/>
-<wire x1="81.15" y1="13.35" x2="81.15" y2="25.2" width="1" layer="1"/>
-<wire x1="81.15" y1="25.2" x2="80.15" y2="26.2" width="1" layer="1"/>
-<wire x1="78.95" y1="26.2" x2="80.15" y2="26.2" width="1" layer="1"/>
-<wire x1="81.15" y1="25.2" x2="81.15" y2="35.6" width="1" layer="1"/>
-<wire x1="81.15" y1="35.6" x2="81.15" y2="47.1" width="1" layer="1"/>
-<wire x1="81.15" y1="47.1" x2="80.4" y2="47.85" width="1" layer="1"/>
-<wire x1="79.05" y1="47.85" x2="80.4" y2="47.85" width="1" layer="1"/>
-<wire x1="79.05" y1="36.97" x2="79.78" y2="36.97" width="1" layer="1"/>
-<wire x1="79.78" y1="36.97" x2="81.15" y2="35.6" width="1" layer="1"/>
-<wire x1="9.05" y1="1.15" x2="21.2" y2="1.15" width="1" layer="1"/>
-<wire x1="21.2" y1="1.15" x2="28.75" y2="1.15" width="1" layer="1"/>
-<wire x1="28.75" y1="1.15" x2="29.75" y2="2.15" width="1" layer="1"/>
+<wire x1="81.15" y1="7.35" x2="81.15" y2="9" width="1" layer="1"/>
+<wire x1="81.15" y1="9" x2="81.15" y2="9.8" width="1" layer="1"/>
+<wire x1="81.15" y1="35.1" x2="81.15" y2="25.2" width="1" layer="1"/>
+<wire x1="81.15" y1="25.2" x2="81.15" y2="23.75" width="1" layer="1"/>
+<wire x1="81.15" y1="23.75" x2="81.15" y2="22.95" width="1" layer="1"/>
+<wire x1="81.15" y1="22.95" x2="81.15" y2="22.25" width="1" layer="1"/>
+<wire x1="81.15" y1="35.1" x2="81.15" y2="41.55" width="1" layer="1"/>
+<wire x1="81.15" y1="41.55" x2="81.15" y2="42.35" width="1" layer="1"/>
+<wire x1="81.15" y1="42.35" x2="81.15" y2="43.1" width="1" layer="1"/>
+<wire x1="81.15" y1="43.1" x2="81.15" y2="43.85" width="1" layer="1"/>
+<wire x1="81.15" y1="43.85" x2="81.15" y2="44.65" width="1" layer="1"/>
+<wire x1="81.15" y1="44.65" x2="81.15" y2="47.1" width="1" layer="1"/>
+<wire x1="29.75" y1="2.15" x2="28.75" y2="1.15" width="1" layer="1"/>
 <wire x1="33.85" y1="1.15" x2="34.83" y2="2.13" width="1" layer="1"/>
 <wire x1="29.75" y1="2.84" x2="29.75" y2="2.4" width="1" layer="1"/>
 <wire x1="29.75" y1="2.4" x2="31" y2="1.15" width="1" layer="1"/>
-<via x="38" y="29.25" extent="1-16" drill="1.25"/>
-<wire x1="60.125" y1="29.162" x2="60.125" y2="28.275" width="0.4" layer="1"/>
-<wire x1="60.125" y1="28.275" x2="61.15" y2="27.25" width="0.4" layer="1"/>
-<wire x1="61.8" y1="27.25" x2="61.15" y2="27.25" width="0.4" layer="1"/>
-<via x="62" y="29.25" extent="1-16" drill="1.25"/>
-<contactref element="RN2" pad="1"/>
-<contactref element="RN1" pad="6"/>
-<wire x1="66.4" y1="30.763" x2="66.4" y2="30.15" width="0.5" layer="1"/>
-<wire x1="66.4" y1="30.15" x2="66.4" y2="24.587" width="0.5" layer="1"/>
-<wire x1="65.8" y1="29.5" x2="66.4" y2="30.15" width="0.4" layer="1"/>
 <contactref element="R6" pad="1"/>
 <contactref element="R7" pad="1"/>
 <wire x1="34.83" y1="2.84" x2="34.83" y2="2.02" width="1" layer="1"/>
 <wire x1="34.83" y1="2.02" x2="35.75" y2="1.1" width="1" layer="1"/>
-<wire x1="35.75" y1="1.1" x2="74.95" y2="1.1" width="1" layer="1"/>
-<wire x1="11.45" y1="6.32" x2="11.45" y2="8.72" width="0.3" layer="1"/>
-<wire x1="9.75" y1="8.52" x2="8.911421875" y2="8.52" width="0.3" layer="1"/>
-<wire x1="8.911421875" y1="8.52" x2="7.08" y2="8.52" width="0.3" layer="1"/>
-<wire x1="7.08" y1="8.52" x2="7" y2="8.6" width="0.3" layer="1"/>
-<wire x1="15.9" y1="29.25" x2="11.97" y2="33.18" width="1" layer="1"/>
-<wire x1="11.97" y1="35.645" x2="11.97" y2="33.18" width="1" layer="1"/>
-<wire x1="7" y1="8.6" x2="7" y2="11.128" width="1" layer="1"/>
-<wire x1="7" y1="11.128" x2="7.022" y2="11.15" width="1" layer="1"/>
-<wire x1="7.022" y1="11.15" x2="7.022" y2="13.022" width="1" layer="1"/>
-<wire x1="7.022" y1="13.022" x2="7.05" y2="13.05" width="1" layer="1"/>
-<via x="7.05" y="13.05" extent="1-16" drill="1.25"/>
-<wire x1="7.05" y1="13.05" x2="7.05" y2="27.85" width="1" layer="16"/>
-<via x="7.05" y="27.85" extent="1-16" drill="1.25"/>
-<wire x1="7.05" y1="27.85" x2="7.05" y2="28.26" width="1" layer="1"/>
-<wire x1="7.05" y1="28.26" x2="11.97" y2="33.18" width="1" layer="1"/>
-<wire x1="7" y1="8.6" x2="7" y2="3.2" width="1" layer="1"/>
-<wire x1="7" y1="3.2" x2="9.05" y2="1.15" width="1" layer="1"/>
-<wire x1="22.65" y1="12.328" x2="22.65" y2="2.6" width="0.3" layer="1"/>
-<wire x1="22.65" y1="2.6" x2="21.2" y2="1.15" width="0.3" layer="1"/>
-<wire x1="8.911421875" y1="8.52" x2="8.911421875" y2="9.011421875" width="0.3" layer="1"/>
-<wire x1="8.911421875" y1="9.011421875" x2="9.5" y2="9.6" width="0.3" layer="1"/>
-<wire x1="9.5" y1="9.6" x2="11.15" y2="9.6" width="0.3" layer="1"/>
-<wire x1="11.45" y1="8.72" x2="11.45" y2="9.3" width="0.3" layer="1"/>
-<wire x1="11.45" y1="9.3" x2="11.15" y2="9.6" width="0.3" layer="1"/>
-<wire x1="65.8" y1="29.5" x2="62.25" y2="29.5" width="0.4" layer="1"/>
-<wire x1="62.25" y1="29.5" x2="62" y2="29.25" width="0.4" layer="1"/>
-<wire x1="62" y1="29.25" x2="38" y2="29.25" width="1" layer="16"/>
-<wire x1="38" y1="29.25" x2="15.9" y2="29.25" width="1" layer="1"/>
-<wire x1="74.95" y1="1.1" x2="76.8" y2="2.95" width="1" layer="1"/>
-<wire x1="76.8" y1="2.95" x2="81.15" y2="7.3" width="1" layer="1"/>
-<wire x1="62" y1="29.25" x2="62" y2="27.45" width="1" layer="1"/>
-<wire x1="62" y1="27.45" x2="61.8" y2="27.25" width="1" layer="1"/>
-<wire x1="79.5" y1="15" x2="81.15" y2="13.35" width="1" layer="1"/>
-<wire x1="76.8" y1="6.378" x2="76.8" y2="2.95" width="1" layer="1"/>
-<wire x1="22.65" y1="12.328" x2="22.672" y2="12.35" width="0.3" layer="1"/>
+<wire x1="35.75" y1="1.1" x2="74.9" y2="1.1" width="1" layer="1"/>
+<wire x1="8.875" y1="5.545" x2="8.875" y2="7.945" width="0.3" layer="1"/>
+<wire x1="74.9" y1="1.1" x2="81.15" y2="7.35" width="1" layer="1"/>
+<wire x1="12.47" y1="30.02" x2="0.55" y2="18.1" width="1" layer="1"/>
+<wire x1="0.55" y1="18.1" x2="0.55" y2="11.3" width="1" layer="1"/>
+<wire x1="12.47" y1="35.01" x2="12.47" y2="30.02" width="1" layer="1"/>
+<wire x1="0.55" y1="7.8" x2="7.2" y2="1.15" width="1" layer="1"/>
+<wire x1="7.2" y1="1.15" x2="11.8" y2="1.15" width="1" layer="1"/>
+<wire x1="6.6" y1="11.6" x2="6.6" y2="9.65" width="1" layer="1"/>
+<wire x1="28.75" y1="1.15" x2="22.1" y2="1.15" width="1" layer="1"/>
+<wire x1="75.962" y1="15.345" x2="74.355" y2="15.345" width="0.4" layer="1"/>
+<wire x1="74.355" y1="15.345" x2="74.35" y2="15.35" width="0.4" layer="1"/>
+<via x="74.35" y="15.35" extent="1-16" drill="0.45"/>
+<wire x1="74.35" y1="15.35" x2="67.4" y2="15.35" width="0.4" layer="16"/>
+<via x="67.4" y="15.35" extent="1-16" drill="0.45"/>
+<wire x1="67.4" y1="15.35" x2="66.55" y2="15.35" width="0.4" layer="1"/>
+<wire x1="6.6" y1="11.6" x2="10.578" y2="11.6" width="1" layer="1"/>
+<wire x1="13.6" y1="3" x2="11.8" y2="1.2" width="1" layer="1"/>
+<wire x1="11.8" y1="1.2" x2="11.8" y2="1.15" width="1" layer="1"/>
+<wire x1="79.3" y1="36.4" x2="79.85" y2="36.4" width="1" layer="1"/>
+<wire x1="79.85" y1="36.4" x2="81.15" y2="35.1" width="1" layer="1"/>
+<wire x1="22.1" y1="1.15" x2="11.8" y2="1.15" width="1" layer="1"/>
+<wire x1="23.322" y1="3.65" x2="23.322" y2="2.372" width="1" layer="1"/>
+<wire x1="23.322" y1="2.372" x2="22.1" y2="1.15" width="1" layer="1"/>
+<wire x1="8.875" y1="7.945" x2="8.875" y2="9.325" width="0.3" layer="1"/>
+<wire x1="81.15" y1="22.25" x2="81.15" y2="21.45" width="1" layer="1"/>
+<wire x1="81.15" y1="21.45" x2="81.15" y2="13.5" width="1" layer="1"/>
+<wire x1="81.15" y1="13.5" x2="81.15" y2="12.05" width="1" layer="1"/>
+<wire x1="81.15" y1="12.05" x2="81.15" y2="11.25" width="1" layer="1"/>
+<wire x1="81.15" y1="11.25" x2="81.15" y2="10.4" width="1" layer="1"/>
+<wire x1="81.15" y1="10.4" x2="81.15" y2="9.8" width="1" layer="1"/>
+<wire x1="79.28" y1="36.42" x2="79.3" y2="36.4" width="0.3" layer="1"/>
+<wire x1="78.903571875" y1="36.575" x2="79.28" y2="36.42" width="0.3" layer="1"/>
+<wire x1="23.322" y1="3.65" x2="25.1" y2="5.428" width="1" layer="1"/>
+<wire x1="23.35" y1="11.6" x2="20.372" y2="11.6" width="1" layer="1"/>
+<wire x1="25.1" y1="5.428" x2="25.1" y2="9.85" width="1" layer="1"/>
+<wire x1="25.1" y1="9.85" x2="23.35" y2="11.6" width="1" layer="1"/>
+<wire x1="17.3" y1="6.75" x2="16.4" y2="6.75" width="0.3" layer="1"/>
+<wire x1="16.4" y1="6.75" x2="13.6" y2="3.95" width="0.3" layer="1"/>
+<wire x1="13.6" y1="3.95" x2="13.6" y2="3" width="0.3" layer="1"/>
+<wire x1="4.4" y1="9.65" x2="6.305" y2="7.745" width="0.3" layer="1"/>
+<wire x1="7.175" y1="7.745" x2="6.305" y2="7.745" width="0.3" layer="1"/>
+<wire x1="8.875" y1="9.325" x2="8.55" y2="9.65" width="0.3" layer="1"/>
+<wire x1="8.55" y1="9.65" x2="6.6" y2="9.65" width="0.3" layer="1"/>
+<wire x1="6.6" y1="9.65" x2="4.4" y2="9.65" width="1" layer="1"/>
+<wire x1="4.4" y1="9.65" x2="2.2" y2="9.65" width="1" layer="1"/>
+<wire x1="2.2" y1="9.65" x2="0.55" y2="11.3" width="1" layer="1"/>
+<wire x1="0.55" y1="11.3" x2="0.55" y2="7.8" width="1" layer="1"/>
+<contactref element="RN6" pad="1"/>
+<contactref element="RN6" pad="2"/>
+<contactref element="RN6" pad="3"/>
+<contactref element="RN6" pad="4"/>
+<contactref element="RN8" pad="1"/>
+<contactref element="RN8" pad="2"/>
+<contactref element="RN8" pad="3"/>
+<contactref element="RN8" pad="4"/>
+<contactref element="RN4" pad="2"/>
+<contactref element="RN4" pad="1"/>
+<contactref element="RN4" pad="3"/>
+<contactref element="RN4" pad="4"/>
+<contactref element="RN2" pad="5"/>
+<contactref element="RN2" pad="6"/>
+<contactref element="RN2" pad="7"/>
+<contactref element="RN2" pad="8"/>
+<contactref element="RN3" pad="5"/>
+<contactref element="RN3" pad="6"/>
+<contactref element="RN3" pad="7"/>
+<contactref element="RN3" pad="8"/>
+<contactref element="RN1" pad="8"/>
+<contactref element="RN1" pad="7"/>
+<contactref element="RN1" pad="6"/>
+<contactref element="RN1" pad="5"/>
+<wire x1="75.988" y1="36.575" x2="78.903571875" y2="36.575" width="0.4" layer="1"/>
+<wire x1="81.05" y1="42.45" x2="81.075" y2="42.425" width="0.4" layer="1"/>
+<wire x1="81.075" y1="42.425" x2="81.15" y2="42.35" width="0.4" layer="1"/>
+<wire x1="81.05" y1="41.65" x2="81.15" y2="41.55" width="0.4" layer="1"/>
+<wire x1="81.1" y1="22.3" x2="81.15" y2="22.25" width="0.4" layer="1"/>
+<wire x1="81.1" y1="9.85" x2="81.15" y2="9.8" width="0.4" layer="1"/>
+<wire x1="66.55" y1="15.35" x2="66.2" y2="15" width="0.4" layer="1"/>
+<wire x1="66.2" y1="15" x2="66.2" y2="12.1" width="0.4" layer="1"/>
+<wire x1="66.2" y1="12.1" x2="66.2" y2="11.3" width="0.4" layer="1"/>
+<wire x1="66.2" y1="11.3" x2="66.2" y2="10.5" width="0.4" layer="1"/>
+<wire x1="66.2" y1="10.5" x2="66.2" y2="9.7" width="0.4" layer="1"/>
+<wire x1="67.4" y1="15.35" x2="66.75" y2="15.35" width="0.4" layer="1"/>
+<wire x1="66.75" y1="15.35" x2="66.2" y2="15.9" width="0.4" layer="1"/>
+<wire x1="66.2" y1="15.9" x2="66.2" y2="21.35" width="0.4" layer="1"/>
+<wire x1="66.2" y1="21.35" x2="66.2" y2="22.15" width="0.4" layer="1"/>
+<wire x1="66.2" y1="22.15" x2="66.2" y2="22.95" width="0.4" layer="1"/>
+<wire x1="66.2" y1="22.95" x2="66.2" y2="23.75" width="0.4" layer="1"/>
+<wire x1="66.2" y1="48.25" x2="66.2" y2="44.7" width="0.4" layer="1"/>
+<wire x1="66.2" y1="48.25" x2="67.3" y2="49.35" width="0.4" layer="1"/>
+<wire x1="66.2" y1="44.7" x2="66.2" y2="43.9" width="0.4" layer="1"/>
+<wire x1="66.2" y1="43.9" x2="66.2" y2="43.1" width="0.4" layer="1"/>
+<wire x1="66.2" y1="43.1" x2="66.2" y2="42.3" width="0.4" layer="1"/>
+<wire x1="67.3" y1="49.35" x2="74.557" y2="49.35" width="0.4" layer="1"/>
+<wire x1="81.15" y1="47.1" x2="77.35" y2="50.9" width="1" layer="1"/>
+<wire x1="77.35" y1="50.9" x2="75.95" y2="50.9" width="1" layer="1"/>
+<wire x1="75.95" y1="50.9" x2="75.95" y2="47.957" width="0.4" layer="1"/>
+<wire x1="75.95" y1="47.957" x2="75.962" y2="47.945" width="0.4" layer="1"/>
+<wire x1="75.962" y1="26.995" x2="79.275" y2="26.995" width="0.4" layer="1"/>
+<wire x1="79.275" y1="26.995" x2="79.3" y2="27.02" width="0.4" layer="1"/>
+<wire x1="80.1" y1="23.75" x2="81.15" y2="23.75" width="0.4" layer="1"/>
+<wire x1="80.1" y1="22.95" x2="81.15" y2="22.95" width="0.4" layer="1"/>
+<wire x1="80.1" y1="22.15" x2="81.05" y2="22.15" width="0.4" layer="1"/>
+<wire x1="81.05" y1="22.15" x2="81.15" y2="22.25" width="0.4" layer="1"/>
+<wire x1="80.1" y1="21.35" x2="81.05" y2="21.35" width="0.4" layer="1"/>
+<wire x1="81.05" y1="21.35" x2="81.15" y2="21.45" width="0.4" layer="1"/>
+<wire x1="75.962" y1="15.345" x2="79.295" y2="15.345" width="0.4" layer="1"/>
+<wire x1="79.295" y1="15.345" x2="79.3" y2="15.35" width="0.4" layer="1"/>
+<wire x1="80.1" y1="44.7" x2="81.1" y2="44.7" width="0.4" layer="1"/>
+<wire x1="81.1" y1="44.7" x2="81.15" y2="44.65" width="0.4" layer="1"/>
+<wire x1="80.1" y1="43.9" x2="81.1" y2="43.9" width="0.4" layer="1"/>
+<wire x1="81.1" y1="43.9" x2="81.15" y2="43.85" width="0.4" layer="1"/>
+<wire x1="80.1" y1="43.1" x2="81.15" y2="43.1" width="0.4" layer="1"/>
+<wire x1="80.1" y1="42.3" x2="80.95" y2="42.3" width="0.4" layer="1"/>
+<wire x1="80.95" y1="42.3" x2="81.075" y2="42.425" width="0.4" layer="1"/>
+<wire x1="80.1" y1="12.1" x2="81.1" y2="12.1" width="0.4" layer="1"/>
+<wire x1="81.1" y1="12.1" x2="81.15" y2="12.05" width="0.4" layer="1"/>
+<wire x1="80.1" y1="11.3" x2="81.1" y2="11.3" width="0.4" layer="1"/>
+<wire x1="81.1" y1="11.3" x2="81.15" y2="11.25" width="0.4" layer="1"/>
+<wire x1="80.1" y1="10.5" x2="81.05" y2="10.5" width="0.4" layer="1"/>
+<wire x1="81.05" y1="10.5" x2="81.15" y2="10.4" width="0.4" layer="1"/>
+<wire x1="80.1" y1="9.7" x2="80.95" y2="9.7" width="0.4" layer="1"/>
+<wire x1="80.95" y1="9.7" x2="81.1" y2="9.85" width="0.4" layer="1"/>
+<wire x1="79.3" y1="15.35" x2="81.15" y2="13.5" width="1" layer="1"/>
+<wire x1="79.3" y1="27.02" x2="81.12" y2="25.2" width="1" layer="1"/>
+<wire x1="81.12" y1="25.2" x2="81.15" y2="25.2" width="1" layer="1"/>
+<wire x1="74.557" y1="49.35" x2="75.95" y2="50.743" width="0.4" layer="1"/>
+<wire x1="75.95" y1="50.743" x2="75.95" y2="50.9" width="0.4" layer="1"/>
 </signal>
 <signal name="BUTTON1">
 <contactref element="FRDM1" pad="A4"/>
 <contactref element="IC1" pad="11"/>
-<contactref element="RN1" pad="10"/>
-<wire x1="76.112" y1="19.745" x2="74.705" y2="19.745" width="0.3" layer="1"/>
-<wire x1="74.705" y1="19.745" x2="74.65" y2="19.75" width="0.3" layer="1"/>
-<via x="74.65" y="19.75" extent="1-16" drill="0.35"/>
-<via x="63.75" y="19.9" extent="1-16" drill="0.35"/>
-<wire x1="65.212" y1="21.25" x2="64.9" y2="21.25" width="0.3" layer="1"/>
-<wire x1="74.65" y1="19.75" x2="70.3" y2="19.75" width="0.3" layer="16"/>
-<wire x1="65.212" y1="21.25" x2="65.2" y2="21.25" width="0.3" layer="1"/>
-<wire x1="70.3" y1="19.75" x2="69.7" y2="20.35" width="0.3" layer="16"/>
-<wire x1="69.7" y1="20.35" x2="66.15" y2="20.35" width="0.3" layer="16"/>
+<wire x1="75.962" y1="8.995" x2="74.505" y2="8.995" width="0.3" layer="1"/>
+<wire x1="74.505" y1="8.995" x2="74.45" y2="9" width="0.3" layer="1"/>
+<via x="74.45" y="9" extent="1-16" drill="0.45"/>
+<via x="63.85" y="9.65" extent="1-16" drill="0.45"/>
+<wire x1="74.45" y1="9" x2="73.8" y2="9.65" width="0.3" layer="16"/>
+<wire x1="73.8" y1="9.65" x2="63.85" y2="9.65" width="0.3" layer="16"/>
 <wire x1="60.23" y1="2.84" x2="60.24" y2="2.84" width="0.3" layer="16"/>
 <wire x1="60.24" y1="2.84" x2="61.5" y2="4.1" width="0.3" layer="16"/>
-<wire x1="63.75" y1="19.9" x2="65.7" y2="19.9" width="0.3" layer="16"/>
-<wire x1="65.7" y1="19.9" x2="66.15" y2="20.35" width="0.3" layer="16"/>
-<wire x1="63.75" y1="19.9" x2="64.2" y2="19.9" width="0.3" layer="1"/>
-<wire x1="64.2" y1="19.9" x2="65.212" y2="20.912" width="0.3" layer="1"/>
-<wire x1="65.212" y1="21.25" x2="65.212" y2="20.912" width="0.3" layer="1"/>
-<wire x1="63.75" y1="19.9" x2="63.55" y2="19.9" width="0.3" layer="16"/>
-<wire x1="61.7" y1="18.05" x2="63.55" y2="19.9" width="0.3" layer="16"/>
-<wire x1="61.5" y1="4.1" x2="61.5" y2="9.4" width="0.3" layer="16"/>
-<wire x1="61.5" y1="9.4" x2="61.7" y2="9.6" width="0.3" layer="16"/>
-<wire x1="61.7" y1="9.6" x2="61.7" y2="18.05" width="0.3" layer="16"/>
+<wire x1="61.5" y1="4.1" x2="61.5" y2="7.35" width="0.3" layer="16"/>
+<wire x1="63.85" y1="9.65" x2="63.8" y2="9.65" width="0.3" layer="16"/>
+<wire x1="63.8" y1="9.65" x2="61.5" y2="7.35" width="0.3" layer="16"/>
+<contactref element="RN3" pad="4"/>
+<wire x1="75.962" y1="8.995" x2="76.605" y2="8.995" width="0.3" layer="1"/>
+<wire x1="78.5" y1="9.7" x2="77.795" y2="8.995" width="0.3" layer="1"/>
+<wire x1="77.795" y1="8.995" x2="75.962" y2="8.995" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON2">
 <contactref element="FRDM1" pad="A3"/>
 <wire x1="57.69" y1="2.84" x2="57.89" y2="2.84" width="0.3" layer="16"/>
 <wire x1="57.89" y1="2.84" x2="58.9" y2="3.85" width="0.3" layer="16"/>
-<wire x1="58.9" y1="3.85" x2="58.9" y2="7.65" width="0.3" layer="16"/>
-<contactref element="RN1" pad="3"/>
 <contactref element="IC1" pad="5"/>
-<wire x1="61.05" y1="9.8" x2="61.05" y2="18.35" width="0.3" layer="16"/>
-<wire x1="69.2" y1="20.95" x2="65.45" y2="20.95" width="0.3" layer="16"/>
-<wire x1="65.45" y1="20.95" x2="65.1" y2="20.6" width="0.3" layer="16"/>
-<wire x1="63.3" y1="20.6" x2="65.1" y2="20.6" width="0.3" layer="16"/>
-<wire x1="63.3" y1="20.6" x2="61.05" y2="18.35" width="0.3" layer="16"/>
-<via x="69.2" y="20.95" extent="1-16" drill="0.3"/>
-<wire x1="70.688" y1="21.015" x2="69.265" y2="21.015" width="0.3" layer="1"/>
-<wire x1="69.265" y1="21.015" x2="69.2" y2="20.95" width="0.3" layer="1"/>
-<wire x1="67.588" y1="22.05" x2="68.3" y2="22.05" width="0.3" layer="1"/>
-<wire x1="69.2" y1="20.95" x2="69.2" y2="21.15" width="0.3" layer="1"/>
-<wire x1="69.2" y1="21.15" x2="68.3" y2="22.05" width="0.3" layer="1"/>
-<wire x1="61.05" y1="9.8" x2="58.9" y2="7.65" width="0.3" layer="16"/>
+<via x="69.15" y="10.25" extent="1-16" drill="0.45"/>
+<wire x1="70.538" y1="10.265" x2="69.165" y2="10.265" width="0.3" layer="1"/>
+<wire x1="69.165" y1="10.265" x2="69.15" y2="10.25" width="0.3" layer="1"/>
+<wire x1="58.9" y1="7.6177" x2="61.5323" y2="10.25" width="0.3" layer="16"/>
+<wire x1="58.9" y1="3.85" x2="58.9" y2="7.6177" width="0.3" layer="16"/>
+<wire x1="61.5323" y1="10.25" x2="69.15" y2="10.25" width="0.3" layer="16"/>
+<contactref element="RN8" pad="6"/>
+<wire x1="67.8" y1="10.5" x2="68.9" y2="10.5" width="0.3" layer="1"/>
+<wire x1="68.9" y1="10.5" x2="69.15" y2="10.25" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON3">
 <contactref element="FRDM1" pad="A2"/>
 <wire x1="55.15" y1="2.84" x2="55.34" y2="2.84" width="0.3" layer="16"/>
 <wire x1="55.34" y1="2.84" x2="56.4" y2="3.9" width="0.3" layer="16"/>
-<contactref element="RN1" pad="9"/>
 <contactref element="IC1" pad="12"/>
-<via x="74.65" y="21" extent="1-16" drill="0.35"/>
-<wire x1="60.35" y1="10.2" x2="60.35" y2="18.7" width="0.3" layer="16"/>
-<wire x1="76.112" y1="21.015" x2="74.665" y2="21.015" width="0.3" layer="1"/>
-<wire x1="74.665" y1="21.015" x2="74.65" y2="21" width="0.3" layer="1"/>
-<wire x1="74.65" y1="21" x2="71.2" y2="21" width="0.3" layer="16"/>
-<wire x1="71.2" y1="21" x2="70.6" y2="21.6" width="0.3" layer="16"/>
-<wire x1="70.6" y1="21.6" x2="64.95" y2="21.6" width="0.3" layer="16"/>
-<wire x1="64.7" y1="21.35" x2="64.95" y2="21.6" width="0.3" layer="16"/>
-<via x="63.75" y="21.35" extent="1-16" drill="0.35"/>
-<wire x1="63.95" y1="21.35" x2="64.65" y2="22.05" width="0.3" layer="1"/>
-<wire x1="65.212" y1="22.05" x2="64.65" y2="22.05" width="0.3" layer="1"/>
-<wire x1="63.75" y1="21.35" x2="64.7" y2="21.35" width="0.3" layer="16"/>
-<wire x1="63.75" y1="21.35" x2="63.95" y2="21.35" width="0.3" layer="1"/>
-<wire x1="63.75" y1="21.35" x2="63" y2="21.35" width="0.3" layer="16"/>
-<wire x1="63" y1="21.35" x2="60.35" y2="18.7" width="0.3" layer="16"/>
-<wire x1="56.4" y1="3.9" x2="56.4" y2="6.25" width="0.3" layer="16"/>
-<wire x1="60.35" y1="10.2" x2="56.4" y2="6.25" width="0.3" layer="16"/>
+<via x="74.45" y="10.25" extent="1-16" drill="0.45"/>
+<wire x1="75.962" y1="10.265" x2="74.465" y2="10.265" width="0.3" layer="1"/>
+<wire x1="74.465" y1="10.265" x2="74.45" y2="10.25" width="0.3" layer="1"/>
+<wire x1="74.45" y1="10.25" x2="73.8" y2="10.9" width="0.3" layer="16"/>
+<wire x1="73.8" y1="10.9" x2="63.8" y2="10.9" width="0.3" layer="16"/>
+<via x="63.8" y="10.9" extent="1-16" drill="0.45"/>
+<wire x1="56.4" y1="3.9" x2="56.4" y2="7" width="0.3" layer="16"/>
+<wire x1="56.4" y1="7" x2="60.3" y2="10.9" width="0.3" layer="16"/>
+<wire x1="60.3" y1="10.9" x2="63.8" y2="10.9" width="0.3" layer="16"/>
+<contactref element="RN3" pad="3"/>
+<wire x1="75.962" y1="10.265" x2="76.35" y2="10.265" width="0.3" layer="1"/>
+<wire x1="78.5" y1="10.5" x2="76.585" y2="10.5" width="0.3" layer="1"/>
+<wire x1="76.585" y1="10.5" x2="76.35" y2="10.265" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON4">
 <contactref element="FRDM1" pad="A1"/>
-<via x="69.25" y="22.25" extent="1-16" drill="0.35"/>
+<via x="69.15" y="11.5" extent="1-16" drill="0.45"/>
 <wire x1="52.61" y1="2.84" x2="52.89" y2="2.84" width="0.3" layer="16"/>
 <wire x1="52.89" y1="2.84" x2="53.85" y2="3.8" width="0.3" layer="16"/>
 <contactref element="IC1" pad="4"/>
-<contactref element="RN1" pad="4"/>
-<wire x1="67.588" y1="22.85" x2="68.55" y2="22.85" width="0.3" layer="1"/>
-<wire x1="69.25" y1="22.25" x2="69.15" y2="22.25" width="0.3" layer="1"/>
-<wire x1="69.15" y1="22.25" x2="68.55" y2="22.85" width="0.3" layer="1"/>
-<wire x1="69.25" y1="22.25" x2="70.653" y2="22.25" width="0.3" layer="1"/>
-<wire x1="70.653" y1="22.25" x2="70.688" y2="22.285" width="0.3" layer="1"/>
-<wire x1="64.5" y1="22.1" x2="64.65" y2="22.25" width="0.3" layer="16"/>
-<wire x1="69.25" y1="22.25" x2="64.65" y2="22.25" width="0.3" layer="16"/>
-<wire x1="64.5" y1="22.1" x2="62.95" y2="22.1" width="0.3" layer="16"/>
-<wire x1="62.95" y1="22.1" x2="59.65" y2="18.8" width="0.3" layer="16"/>
-<wire x1="59.65" y1="18.8" x2="59.65" y2="10.35" width="0.3" layer="16"/>
-<wire x1="54.3" y1="6.75" x2="53.85" y2="6.3" width="0.3" layer="16"/>
+<wire x1="69.15" y1="11.5" x2="70.503" y2="11.5" width="0.3" layer="1"/>
+<wire x1="70.503" y1="11.5" x2="70.538" y2="11.535" width="0.3" layer="1"/>
+<wire x1="53.85" y1="6.3" x2="54.2" y2="6.65" width="0.3" layer="16"/>
 <wire x1="53.85" y1="3.8" x2="53.85" y2="6.3" width="0.3" layer="16"/>
-<wire x1="54.3" y1="6.75" x2="56.05" y2="6.75" width="0.3" layer="16"/>
-<wire x1="59.65" y1="10.35" x2="56.05" y2="6.75" width="0.3" layer="16"/>
+<wire x1="55.096125" y1="6.65" x2="59.946125" y2="11.5" width="0.3" layer="16"/>
+<wire x1="54.2" y1="6.65" x2="55.096125" y2="6.65" width="0.3" layer="16"/>
+<wire x1="59.946125" y1="11.5" x2="69.15" y2="11.5" width="0.3" layer="16"/>
+<contactref element="RN8" pad="7"/>
+<wire x1="67.8" y1="11.3" x2="68.95" y2="11.3" width="0.3" layer="1"/>
+<wire x1="68.95" y1="11.3" x2="69.15" y2="11.5" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON5">
 <contactref element="FRDM1" pad="PTE30"/>
-<via x="69.15" y="19.7" extent="1-16" drill="0.35"/>
+<via x="69.15" y="9" extent="1-16" drill="0.45"/>
 <contactref element="IC1" pad="6"/>
-<contactref element="RN1" pad="2"/>
-<wire x1="70.688" y1="19.745" x2="69.195" y2="19.745" width="0.3" layer="1"/>
-<wire x1="69.195" y1="19.745" x2="69.15" y2="19.7" width="0.3" layer="1"/>
-<wire x1="69.15" y1="19.7" x2="66.6" y2="19.7" width="0.3" layer="16"/>
-<wire x1="63.7" y1="19.1" x2="66" y2="19.1" width="0.3" layer="16"/>
-<wire x1="66" y1="19.1" x2="66.6" y2="19.7" width="0.3" layer="16"/>
-<wire x1="62.2" y1="17.6" x2="63.7" y2="19.1" width="0.3" layer="16"/>
-<wire x1="69.195" y1="19.745" x2="68.755" y2="19.745" width="0.3" layer="1"/>
-<wire x1="68.755" y1="19.745" x2="67.588" y2="20.912" width="0.3" layer="1"/>
-<wire x1="67.588" y1="21.25" x2="67.588" y2="20.912" width="0.3" layer="1"/>
-<wire x1="62.77" y1="5.38" x2="62.77" y2="8.98" width="0.3" layer="16"/>
-<wire x1="62.77" y1="8.98" x2="62.2" y2="9.55" width="0.3" layer="16"/>
-<wire x1="62.2" y1="9.55" x2="62.2" y2="17.6" width="0.3" layer="16"/>
+<wire x1="69.145" y1="8.995" x2="69.15" y2="9" width="0.3" layer="1"/>
+<wire x1="69.15" y1="9" x2="70.533" y2="9" width="0.3" layer="1"/>
+<wire x1="70.533" y1="9" x2="70.538" y2="8.995" width="0.3" layer="1"/>
+<wire x1="69.15" y1="9" x2="65.55" y2="9" width="0.3" layer="16"/>
+<wire x1="65.55" y1="9" x2="62.77" y2="6.22" width="0.3" layer="16"/>
+<wire x1="62.77" y1="6.22" x2="62.77" y2="5.38" width="0.3" layer="16"/>
+<contactref element="RN8" pad="5"/>
+<wire x1="67.8" y1="9.7" x2="68.505" y2="8.995" width="0.3" layer="1"/>
+<wire x1="68.505" y1="8.995" x2="69.145" y2="8.995" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON6">
 <contactref element="FRDM1" pad="PTC11"/>
-<via x="74.6" y="23.55" extent="1-16" drill="0.35"/>
-<via x="63.75" y="24.1" extent="1-16" drill="0.35"/>
-<wire x1="44.99" y1="48.56" x2="44.99" y2="39.61" width="0.3" layer="1"/>
-<wire x1="48.15" y1="24.75" x2="46.3" y2="26.6" width="0.3" layer="1"/>
-<wire x1="46.3" y1="26.6" x2="46.3" y2="38.3" width="0.3" layer="1"/>
-<wire x1="46.3" y1="38.3" x2="44.99" y2="39.61" width="0.3" layer="1"/>
-<via x="48.15" y="24.75" extent="1-16" drill="0.35"/>
-<via x="55.15" y="24.75" extent="1-16" drill="0.35"/>
-<wire x1="48.15" y1="24.75" x2="55.15" y2="24.75" width="0.3" layer="16"/>
+<via x="74.45" y="12.8" extent="1-16" drill="0.45"/>
+<via x="63.8" y="13.425" extent="1-16" drill="0.45"/>
+<wire x1="52.64" y1="40.06" x2="45.24" y2="47.46" width="0.4" layer="1"/>
+<wire x1="44.99" y1="48.56" x2="45.24" y2="48.31" width="0.4" layer="1"/>
+<wire x1="45.24" y1="48.31" x2="45.24" y2="47.46" width="0.4" layer="1"/>
 <contactref element="IC1" pad="14"/>
-<contactref element="RN1" pad="7"/>
-<wire x1="63.75" y1="24.1" x2="61.7" y2="24.1" width="0.3" layer="1"/>
-<wire x1="63.75" y1="24.1" x2="64.762" y2="24.1" width="0.3" layer="1"/>
-<wire x1="64.762" y1="24.1" x2="65.212" y2="23.65" width="0.3" layer="1"/>
-<wire x1="76.112" y1="23.555" x2="74.605" y2="23.555" width="0.3" layer="1"/>
-<wire x1="74.605" y1="23.555" x2="74.6" y2="23.55" width="0.3" layer="1"/>
-<wire x1="74.6" y1="23.55" x2="70.8" y2="23.55" width="0.3" layer="16"/>
-<wire x1="70.8" y1="23.55" x2="70.05" y2="24.3" width="0.3" layer="16"/>
-<wire x1="70.05" y1="24.3" x2="63.95" y2="24.3" width="0.3" layer="16"/>
-<wire x1="63.95" y1="24.3" x2="63.75" y2="24.1" width="0.3" layer="16"/>
-<wire x1="61.05" y1="24.75" x2="61.7" y2="24.1" width="0.3" layer="1"/>
-<wire x1="61.05" y1="24.75" x2="55.15" y2="24.75" width="0.3" layer="1"/>
+<wire x1="63.8" y1="13.425" x2="63.8" y2="13.412" width="0.3" layer="1"/>
+<wire x1="75.962" y1="12.805" x2="74.455" y2="12.805" width="0.3" layer="1"/>
+<wire x1="74.455" y1="12.805" x2="74.45" y2="12.8" width="0.3" layer="1"/>
+<wire x1="74.45" y1="12.8" x2="73.825" y2="13.425" width="0.3" layer="16"/>
+<wire x1="73.825" y1="13.425" x2="63.8" y2="13.425" width="0.3" layer="16"/>
+<via x="52.64" y="40.06" extent="1-16" drill="0.45"/>
+<wire x1="52.64" y1="40.06" x2="56.29" y2="40.06" width="0.4" layer="16"/>
+<wire x1="59.8418" y1="36.5" x2="59.8418" y2="36.5082" width="0.4" layer="16"/>
+<wire x1="59.8418" y1="36.5082" x2="56.29" y2="40.06" width="0.4" layer="16"/>
+<via x="59.8418" y="36.5" extent="1-16" drill="0.45"/>
+<wire x1="59.8418" y1="36.5" x2="59.8418" y2="20.0582" width="0.4" layer="1"/>
+<wire x1="59.8418" y1="20.0582" x2="63.8" y2="16.1" width="0.4" layer="1"/>
+<contactref element="RN3" pad="1"/>
+<wire x1="75.962" y1="12.805" x2="76.545" y2="12.805" width="0.3" layer="1"/>
+<wire x1="63.8" y1="13.425" x2="63.8" y2="16.1" width="0.4" layer="1"/>
+<wire x1="75.962" y1="12.805" x2="77.795" y2="12.805" width="0.3" layer="1"/>
+<wire x1="77.795" y1="12.805" x2="78.5" y2="12.1" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON7">
 <contactref element="FRDM1" pad="PTE5"/>
 <wire x1="44.99" y1="5.38" x2="44.99" y2="5.79" width="0.3" layer="16"/>
-<wire x1="44.99" y1="5.79" x2="46.45" y2="7.25" width="0.3" layer="16"/>
-<contactref element="RN1" pad="8"/>
 <contactref element="IC1" pad="13"/>
-<via x="63.75" y="22.75" extent="1-16" drill="0.3"/>
-<wire x1="76.112" y1="22.285" x2="74.635" y2="22.285" width="0.3" layer="1"/>
-<wire x1="74.635" y1="22.285" x2="74.6" y2="22.25" width="0.3" layer="1"/>
-<via x="74.6" y="22.25" extent="1-16" drill="0.3"/>
-<wire x1="74.6" y1="22.25" x2="70.6" y2="22.25" width="0.3" layer="16"/>
-<wire x1="70.6" y1="22.25" x2="69.9" y2="22.95" width="0.3" layer="16"/>
-<wire x1="63.75" y1="22.75" x2="64.35" y2="22.75" width="0.3" layer="1"/>
-<wire x1="65.212" y1="22.85" x2="64.45" y2="22.85" width="0.3" layer="1"/>
-<wire x1="64.45" y1="22.85" x2="64.35" y2="22.75" width="0.3" layer="1"/>
-<wire x1="63.75" y1="22.75" x2="64.2" y2="22.75" width="0.3" layer="16"/>
-<wire x1="64.2" y1="22.75" x2="64.4" y2="22.95" width="0.3" layer="16"/>
-<wire x1="64.4" y1="22.95" x2="69.9" y2="22.95" width="0.3" layer="16"/>
-<wire x1="59" y1="19" x2="62.75" y2="22.75" width="0.3" layer="16"/>
-<wire x1="63.75" y1="22.75" x2="62.75" y2="22.75" width="0.3" layer="16"/>
-<wire x1="59" y1="19" x2="59" y2="10.55" width="0.3" layer="16"/>
-<wire x1="55.7" y1="7.25" x2="46.45" y2="7.25" width="0.3" layer="16"/>
-<wire x1="59" y1="10.55" x2="55.7" y2="7.25" width="0.3" layer="16"/>
+<via x="63.825" y="12.175" extent="1-16" drill="0.45"/>
+<wire x1="75.962" y1="11.535" x2="74.465" y2="11.535" width="0.3" layer="1"/>
+<wire x1="74.465" y1="11.535" x2="74.45" y2="11.55" width="0.3" layer="1"/>
+<via x="74.45" y="11.55" extent="1-16" drill="0.45"/>
+<wire x1="74.45" y1="11.55" x2="73.825" y2="12.175" width="0.3" layer="16"/>
+<wire x1="73.825" y1="12.175" x2="63.825" y2="12.175" width="0.3" layer="16"/>
+<wire x1="46.473" y1="7.273" x2="54.801875" y2="7.273" width="0.3" layer="16"/>
+<wire x1="54.801875" y1="7.273" x2="59.703875" y2="12.175" width="0.3" layer="16"/>
+<wire x1="44.99" y1="5.79" x2="46.473" y2="7.273" width="0.3" layer="16"/>
+<wire x1="59.703875" y1="12.175" x2="63.825" y2="12.175" width="0.3" layer="16"/>
+<contactref element="RN3" pad="2"/>
+<wire x1="76.415" y1="11.535" x2="75.962" y2="11.535" width="0.3" layer="1"/>
+<wire x1="78.5" y1="11.3" x2="76.65" y2="11.3" width="0.3" layer="1"/>
+<wire x1="76.65" y1="11.3" x2="76.415" y2="11.535" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON8">
 <contactref element="FRDM1" pad="PTE4"/>
-<via x="69.25" y="23.6" extent="1-16" drill="0.35"/>
-<wire x1="42.45" y1="5.38" x2="42.45" y2="5.5" width="0.3" layer="16"/>
 <contactref element="IC1" pad="3"/>
-<contactref element="RN1" pad="5"/>
-<wire x1="70.688" y1="23.555" x2="69.295" y2="23.555" width="0.3" layer="1"/>
-<wire x1="69.295" y1="23.555" x2="69.25" y2="23.6" width="0.3" layer="1"/>
-<wire x1="67.588" y1="23.65" x2="69.2" y2="23.65" width="0.3" layer="1"/>
-<wire x1="69.2" y1="23.65" x2="69.25" y2="23.6" width="0.3" layer="1"/>
-<wire x1="69.2" y1="23.55" x2="69.25" y2="23.6" width="0.3" layer="16"/>
-<wire x1="69.25" y1="23.6" x2="65.2" y2="23.6" width="0.3" layer="16"/>
-<wire x1="65" y1="23.4" x2="65.2" y2="23.6" width="0.3" layer="16"/>
-<wire x1="65" y1="23.4" x2="62.5" y2="23.4" width="0.3" layer="16"/>
-<wire x1="62.5" y1="23.4" x2="58.35" y2="19.25" width="0.3" layer="16"/>
-<wire x1="58.35" y1="19.25" x2="58.35" y2="10.65" width="0.3" layer="16"/>
-<wire x1="55.45" y1="7.75" x2="44" y2="7.75" width="0.3" layer="16"/>
-<wire x1="44" y1="7.75" x2="42.45" y2="6.2" width="0.3" layer="16"/>
-<wire x1="42.45" y1="5.38" x2="42.45" y2="6.2" width="0.3" layer="16"/>
-<wire x1="58.35" y1="10.65" x2="55.45" y2="7.75" width="0.3" layer="16"/>
+<wire x1="42.45" y1="5.38" x2="42.45" y2="5.4" width="0.3" layer="16"/>
+<wire x1="69.155" y1="12.805" x2="70.538" y2="12.805" width="0.3" layer="1"/>
+<wire x1="69.15" y1="12.8" x2="69.155" y2="12.805" width="0.3" layer="1"/>
+<via x="69.15" y="12.8" extent="1-16" drill="0.45"/>
+<wire x1="42.45" y1="5.4" x2="44.9" y2="7.85" width="0.3" layer="16"/>
+<wire x1="44.9" y1="7.85" x2="54.5" y2="7.85" width="0.3" layer="16"/>
+<wire x1="54.5" y1="7.85" x2="59.45" y2="12.8" width="0.3" layer="16"/>
+<wire x1="59.45" y1="12.8" x2="69.15" y2="12.8" width="0.3" layer="16"/>
+<contactref element="RN8" pad="8"/>
+<wire x1="67.8" y1="12.1" x2="68.5" y2="12.8" width="0.3" layer="1"/>
+<wire x1="68.5" y1="12.8" x2="69.15" y2="12.8" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON16">
 <contactref element="FRDM1" pad="PTC13"/>
-<via x="69.25" y="34.4" extent="1-16" drill="0.35"/>
-<wire x1="60.7" y1="42.2" x2="39.7" y2="42.2" width="0.3" layer="16"/>
-<wire x1="39.7" y1="42.2" x2="39.25" y2="42.65" width="0.3" layer="16"/>
-<via x="39.25" y="42.65" extent="1-16" drill="0.35"/>
+<via x="69.15" y="24.45" extent="1-16" drill="0.45"/>
+<wire x1="39.25" y1="42.65" x2="39.7" y2="42.2" width="0.3" layer="16"/>
+<via x="39.25" y="42.65" extent="1-16" drill="0.45"/>
 <wire x1="38.64" y1="48.56" x2="38.64" y2="43.26" width="0.3" layer="1"/>
 <wire x1="38.64" y1="43.26" x2="39.25" y2="42.65" width="0.3" layer="1"/>
-<wire x1="63.2" y1="39.7" x2="60.7" y2="42.2" width="0.3" layer="16"/>
 <contactref element="IC2" pad="3"/>
-<contactref element="RN2" pad="5"/>
-<wire x1="70.688" y1="34.355" x2="69.295" y2="34.355" width="0.3" layer="1"/>
-<wire x1="69.295" y1="34.355" x2="69.25" y2="34.4" width="0.3" layer="1"/>
-<wire x1="67.588" y1="34.1" x2="68.95" y2="34.1" width="0.3" layer="1"/>
-<wire x1="68.95" y1="34.1" x2="69.25" y2="34.4" width="0.3" layer="1"/>
-<wire x1="69.25" y1="34.4" x2="63.75" y2="34.4" width="0.3" layer="16"/>
-<wire x1="63.2" y1="39.7" x2="63.2" y2="34.95" width="0.3" layer="16"/>
-<wire x1="63.2" y1="34.95" x2="63.75" y2="34.4" width="0.3" layer="16"/>
+<wire x1="70.538" y1="24.455" x2="69.155" y2="24.455" width="0.3" layer="1"/>
+<wire x1="69.155" y1="24.455" x2="68.555" y2="24.455" width="0.3" layer="1"/>
+<wire x1="69.155" y1="24.455" x2="69.15" y2="24.45" width="0.3" layer="1"/>
+<wire x1="60.59225" y1="42.2" x2="62.44625" y2="40.346" width="0.3" layer="16"/>
+<wire x1="62.44625" y1="40.346" x2="70.154" y2="40.346" width="0.3" layer="16"/>
+<wire x1="39.7" y1="42.2" x2="60.59225" y2="42.2" width="0.3" layer="16"/>
+<wire x1="70.154" y1="40.346" x2="70.45" y2="40.05" width="0.3" layer="16"/>
+<wire x1="70.45" y1="40.05" x2="70.45" y2="28.9" width="0.3" layer="16"/>
+<wire x1="70.45" y1="28.9" x2="70.2" y2="28.65" width="0.3" layer="16"/>
+<via x="70.2" y="28.65" extent="1-16" drill="0.45"/>
+<wire x1="70.2" y1="28.65" x2="68.55" y2="28.65" width="0.3" layer="1"/>
+<wire x1="68.55" y1="28.65" x2="67.738" y2="27.838" width="0.3" layer="1"/>
+<contactref element="RN6" pad="8"/>
+<wire x1="67.738" y1="27.838" x2="67.738" y2="25.272" width="0.3" layer="1"/>
+<wire x1="67.738" y1="25.272" x2="68.555" y2="24.455" width="0.3" layer="1"/>
+<wire x1="67.8" y1="23.75" x2="68.5" y2="24.45" width="0.3" layer="1"/>
+<wire x1="68.5" y1="24.45" x2="69.15" y2="24.45" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON15">
 <contactref element="FRDM1" pad="PTC12"/>
-<via x="74.55" y="34.35" extent="1-16" drill="0.35"/>
+<via x="74.45" y="24.45" extent="1-16" drill="0.45"/>
 <wire x1="41.18" y1="48.56" x2="41.18" y2="43.42" width="0.3" layer="1"/>
 <via x="41.85" y="42.75" extent="1-16" drill="0.35"/>
-<wire x1="41.85" y1="42.75" x2="60.9" y2="42.75" width="0.3" layer="16"/>
 <wire x1="41.18" y1="43.42" x2="41.85" y2="42.75" width="0.3" layer="1"/>
-<wire x1="60.9" y1="42.75" x2="63.85" y2="39.8" width="0.3" layer="16"/>
-<wire x1="63.85" y1="39.8" x2="63.85" y2="36.35" width="0.3" layer="16"/>
-<contactref element="RN2" pad="7"/>
-<wire x1="65.212" y1="34.1" x2="64.95" y2="34.1" width="0.3" layer="1"/>
 <contactref element="IC2" pad="14"/>
-<wire x1="76.112" y1="34.355" x2="74.555" y2="34.355" width="0.3" layer="1"/>
-<wire x1="74.555" y1="34.355" x2="74.55" y2="34.35" width="0.3" layer="1"/>
-<wire x1="73.65" y1="35.25" x2="74.55" y2="34.35" width="0.3" layer="16"/>
-<wire x1="63.85" y1="36.35" x2="64.95" y2="35.25" width="0.3" layer="16"/>
-<wire x1="64.95" y1="35.25" x2="73.65" y2="35.25" width="0.3" layer="16"/>
-<wire x1="64.95" y1="35.25" x2="63.75" y2="35.25" width="0.3" layer="16"/>
-<via x="63.75" y="35.25" extent="1-16" drill="0.3"/>
-<wire x1="65.212" y1="34.1" x2="64.9" y2="34.1" width="0.3" layer="1"/>
-<wire x1="63.75" y1="35.25" x2="64.05" y2="35.25" width="0.3" layer="1"/>
-<wire x1="65.212" y1="34.1" x2="65.2" y2="34.1" width="0.3" layer="1"/>
-<wire x1="65.2" y1="34.1" x2="64.05" y2="35.25" width="0.3" layer="1"/>
+<wire x1="75.962" y1="24.455" x2="74.455" y2="24.455" width="0.3" layer="1"/>
+<wire x1="74.455" y1="24.455" x2="74.45" y2="24.45" width="0.3" layer="1"/>
+<wire x1="74.45" y1="24.45" x2="73.8" y2="25.1" width="0.3" layer="16"/>
+<wire x1="73.8" y1="25.1" x2="66.8" y2="25.1" width="0.3" layer="16"/>
+<wire x1="60.846125" y1="42.75" x2="62.673125" y2="40.923" width="0.3" layer="16"/>
+<wire x1="70.477" y1="40.923" x2="71.2" y2="40.2" width="0.3" layer="16"/>
+<wire x1="62.673125" y1="40.923" x2="70.477" y2="40.923" width="0.3" layer="16"/>
+<wire x1="41.85" y1="42.75" x2="60.846125" y2="42.75" width="0.3" layer="16"/>
+<wire x1="71.2" y1="28.55" x2="70.55" y2="27.9" width="0.3" layer="16"/>
+<wire x1="70.55" y1="27.9" x2="66.8" y2="27.9" width="0.3" layer="16"/>
+<via x="66.8" y="27.9" extent="1-16" drill="0.45"/>
+<wire x1="71.2" y1="40.2" x2="71.2" y2="28.55" width="0.3" layer="16"/>
+<via x="66.8" y="25.1" extent="1-16" drill="0.45"/>
+<wire x1="66.35" y1="27.45" x2="66.35" y2="25.521875" width="0.3" layer="1"/>
+<wire x1="66.8" y1="25.1" x2="66.35" y2="25.521875" width="0.3" layer="1"/>
+<wire x1="66.35" y1="27.45" x2="66.8" y2="27.9" width="0.3" layer="1"/>
+<contactref element="RN2" pad="1"/>
+<wire x1="75.962" y1="24.455" x2="76.595" y2="24.455" width="0.3" layer="1"/>
+<wire x1="75.962" y1="24.455" x2="77.795" y2="24.455" width="0.3" layer="1"/>
+<wire x1="77.795" y1="24.455" x2="78.5" y2="23.75" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON14">
 <contactref element="FRDM1" pad="PTB8"/>
-<via x="63.7" y="31.95" extent="1-16" drill="0.35"/>
-<wire x1="37.45" y1="33.15" x2="34.05" y2="29.75" width="0.3" layer="16"/>
-<wire x1="34.05" y1="29.75" x2="34.05" y2="9.95" width="0.3" layer="16"/>
-<wire x1="34.05" y1="9.95" x2="34.35" y2="9.65" width="0.3" layer="16"/>
-<via x="34.35" y="9.65" extent="1-16" drill="0.35"/>
-<wire x1="34.35" y1="9.65" x2="28.95" y2="9.65" width="0.3" layer="1"/>
-<wire x1="28.95" y1="9.65" x2="27.21" y2="7.91" width="0.3" layer="1"/>
-<wire x1="27.21" y1="5.38" x2="27.21" y2="7.91" width="0.3" layer="1"/>
-<contactref element="RN2" pad="3"/>
 <contactref element="IC2" pad="5"/>
-<via x="69.25" y="31.85" extent="1-16" drill="0.35"/>
-<wire x1="70.688" y1="31.815" x2="69.285" y2="31.815" width="0.3" layer="1"/>
-<wire x1="69.285" y1="31.815" x2="69.25" y2="31.85" width="0.3" layer="1"/>
-<wire x1="68.6" y1="32.5" x2="69.25" y2="31.85" width="0.3" layer="1"/>
-<wire x1="37.45" y1="33.15" x2="61.7" y2="33.15" width="0.3" layer="16"/>
-<wire x1="61.7" y1="33.15" x2="62.9" y2="31.95" width="0.3" layer="16"/>
-<wire x1="63.7" y1="31.95" x2="62.9" y2="31.95" width="0.3" layer="16"/>
-<wire x1="63.7" y1="31.95" x2="69.15" y2="31.95" width="0.3" layer="16"/>
-<wire x1="69.15" y1="31.95" x2="69.25" y2="31.85" width="0.3" layer="16"/>
-<wire x1="67.588" y1="32.5" x2="68.6" y2="32.5" width="0.3" layer="1"/>
+<via x="69.15" y="21.9" extent="1-16" drill="0.45"/>
+<wire x1="70.538" y1="21.915" x2="69.165" y2="21.915" width="0.3" layer="1"/>
+<wire x1="69.165" y1="21.915" x2="69.15" y2="21.9" width="0.3" layer="1"/>
+<wire x1="69.15" y1="21.9" x2="63.6" y2="21.9" width="0.3" layer="16"/>
+<wire x1="39.55" y1="10.35" x2="36.1" y2="6.9" width="0.3" layer="16"/>
+<wire x1="63.6" y1="21.9" x2="52.05" y2="10.35" width="0.3" layer="16"/>
+<wire x1="52.05" y1="10.35" x2="39.55" y2="10.35" width="0.3" layer="16"/>
+<wire x1="36.1" y1="6.9" x2="36.1" y2="4.3" width="0.3" layer="16"/>
+<wire x1="35.9" y1="4.1" x2="28.5" y2="4.1" width="0.3" layer="16"/>
+<wire x1="28.5" y1="4.1" x2="27.22" y2="5.38" width="0.3" layer="16"/>
+<wire x1="27.21" y1="5.38" x2="27.22" y2="5.38" width="0.3" layer="16"/>
+<wire x1="36.1" y1="4.3" x2="35.9" y2="4.1" width="0.3" layer="16"/>
+<contactref element="RN6" pad="6"/>
+<wire x1="67.8" y1="22.15" x2="68.9" y2="22.15" width="0.3" layer="1"/>
+<wire x1="68.9" y1="22.15" x2="69.15" y2="21.9" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON13">
 <contactref element="FRDM1" pad="PTB9"/>
-<via x="74.55" y="33.05" extent="1-16" drill="0.3"/>
-<wire x1="63.5" y1="33.75" x2="62.05" y2="35.2" width="0.3" layer="16"/>
-<contactref element="RN2" pad="8"/>
 <contactref element="IC2" pad="13"/>
-<wire x1="76.112" y1="33.085" x2="74.585" y2="33.085" width="0.3" layer="1"/>
-<wire x1="74.585" y1="33.085" x2="74.55" y2="33.05" width="0.3" layer="1"/>
-<wire x1="74.55" y1="33.05" x2="71.25" y2="33.05" width="0.3" layer="16"/>
-<wire x1="71.25" y1="33.05" x2="70.55" y2="33.75" width="0.3" layer="16"/>
-<wire x1="70.55" y1="33.75" x2="63.7" y2="33.75" width="0.3" layer="16"/>
-<wire x1="63.7" y1="33.75" x2="63.5" y2="33.75" width="0.3" layer="16"/>
-<via x="63.7" y="33.75" extent="1-16" drill="0.35"/>
-<wire x1="65.212" y1="33.3" x2="64.15" y2="33.3" width="0.3" layer="1"/>
-<wire x1="64.15" y1="33.3" x2="63.7" y2="33.75" width="0.3" layer="1"/>
-<wire x1="62.05" y1="35.2" x2="36.7" y2="35.2" width="0.3" layer="16"/>
-<wire x1="36.7" y1="35.2" x2="32.2" y2="30.7" width="0.3" layer="16"/>
-<wire x1="32.2" y1="30.7" x2="32.2" y2="8.95" width="0.3" layer="16"/>
-<wire x1="32.2" y1="8.95" x2="29.75" y2="6.5" width="0.3" layer="16"/>
-<wire x1="29.75" y1="5.38" x2="29.75" y2="6.5" width="0.3" layer="16"/>
+<via x="63.05" y="23.8" extent="1-16" drill="0.45"/>
+<via x="74.45" y="23.2" extent="1-16" drill="0.45"/>
+<wire x1="74.45" y1="23.2" x2="73.85" y2="23.8" width="0.3" layer="16"/>
+<wire x1="73.85" y1="23.8" x2="63.05" y2="23.8" width="0.3" layer="16"/>
+<wire x1="74.45" y1="23.2" x2="75.947" y2="23.2" width="0.3" layer="1"/>
+<wire x1="75.947" y1="23.2" x2="75.962" y2="23.185" width="0.3" layer="1"/>
+<wire x1="36.703" y1="12.333" x2="29.75" y2="5.38" width="0.3" layer="16"/>
+<wire x1="63.05" y1="23.8" x2="51.583" y2="12.333" width="0.3" layer="16"/>
+<wire x1="51.583" y1="12.333" x2="36.703" y2="12.333" width="0.3" layer="16"/>
+<contactref element="RN2" pad="2"/>
+<wire x1="76.365" y1="23.185" x2="75.962" y2="23.185" width="0.3" layer="1"/>
+<wire x1="78.5" y1="22.95" x2="76.6" y2="22.95" width="0.3" layer="1"/>
+<wire x1="76.6" y1="22.95" x2="76.365" y2="23.185" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON12">
 <contactref element="FRDM1" pad="PTB10"/>
-<via x="69.25" y="33.1" extent="1-16" drill="0.3"/>
-<contactref element="RN2" pad="4"/>
 <contactref element="IC2" pad="4"/>
-<wire x1="70.688" y1="33.085" x2="69.265" y2="33.085" width="0.3" layer="1"/>
-<wire x1="69.265" y1="33.085" x2="69.25" y2="33.1" width="0.3" layer="1"/>
-<wire x1="67.588" y1="33.3" x2="69.05" y2="33.3" width="0.3" layer="1"/>
-<wire x1="69.05" y1="33.3" x2="69.25" y2="33.1" width="0.3" layer="1"/>
-<wire x1="32.29" y1="5.38" x2="32.29" y2="7.59" width="0.3" layer="16"/>
-<wire x1="32.29" y1="7.59" x2="32.85" y2="8.15" width="0.3" layer="16"/>
-<wire x1="32.85" y1="8.15" x2="32.85" y2="30.45" width="0.3" layer="16"/>
-<wire x1="32.85" y1="30.45" x2="37" y2="34.6" width="0.3" layer="16"/>
-<wire x1="37" y1="34.6" x2="61.8" y2="34.6" width="0.3" layer="16"/>
-<wire x1="61.8" y1="34.6" x2="63.25" y2="33.15" width="0.3" layer="16"/>
-<wire x1="63.25" y1="33.15" x2="69.2" y2="33.15" width="0.3" layer="16"/>
-<wire x1="69.2" y1="33.15" x2="69.25" y2="33.1" width="0.3" layer="16"/>
+<wire x1="69.165" y1="23.185" x2="69.15" y2="23.2" width="0.3" layer="1"/>
+<via x="69.15" y="23.2" extent="1-16" drill="0.45"/>
+<wire x1="69.1282" y1="23.1782" x2="69.15" y2="23.2" width="0.3" layer="16"/>
+<wire x1="69.1282" y1="23.1782" x2="63.18120625" y2="23.1782" width="0.3" layer="16"/>
+<wire x1="70.538" y1="23.185" x2="69.165" y2="23.185" width="0.3" layer="1"/>
+<wire x1="63.18120625" y1="23.1782" x2="51.70300625" y2="11.7" width="0.3" layer="16"/>
+<wire x1="51.70300625" y1="11.7" x2="38.61" y2="11.7" width="0.3" layer="16"/>
+<wire x1="38.61" y1="11.7" x2="32.29" y2="5.38" width="0.3" layer="16"/>
+<contactref element="RN6" pad="7"/>
+<wire x1="67.8" y1="22.95" x2="68.9" y2="22.95" width="0.3" layer="1"/>
+<wire x1="68.9" y1="22.95" x2="69.15" y2="23.2" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON11">
 <contactref element="FRDM1" pad="PTB11"/>
-<via x="74.6" y="31.75" extent="1-16" drill="0.35"/>
-<via x="63.7" y="32.6" extent="1-16" drill="0.35"/>
-<wire x1="37.25" y1="33.85" x2="33.45" y2="30.05" width="0.3" layer="16"/>
-<wire x1="33.45" y1="8.4" x2="34.83" y2="7.02" width="0.3" layer="16"/>
-<wire x1="34.83" y1="5.38" x2="34.83" y2="7.02" width="0.3" layer="16"/>
+<via x="74.45" y="21.9" extent="1-16" drill="0.45"/>
+<via x="63.4" y="22.55" extent="1-16" drill="0.45"/>
 <contactref element="IC2" pad="12"/>
-<contactref element="RN2" pad="9"/>
-<wire x1="76.112" y1="31.815" x2="74.665" y2="31.815" width="0.3" layer="1"/>
-<wire x1="74.665" y1="31.815" x2="74.6" y2="31.75" width="0.3" layer="1"/>
-<wire x1="37.25" y1="33.85" x2="61.8" y2="33.85" width="0.3" layer="16"/>
-<wire x1="74.6" y1="31.75" x2="71" y2="31.75" width="0.3" layer="16"/>
-<wire x1="71" y1="31.75" x2="70.2" y2="32.55" width="0.3" layer="16"/>
-<wire x1="65.212" y1="32.5" x2="65.212" y2="32.538" width="0.3" layer="1"/>
-<wire x1="63.05" y1="32.6" x2="61.8" y2="33.85" width="0.3" layer="16"/>
-<wire x1="70.2" y1="32.55" x2="64.6" y2="32.55" width="0.3" layer="16"/>
-<wire x1="63.7" y1="32.6" x2="63.05" y2="32.6" width="0.3" layer="16"/>
-<wire x1="63.7" y1="32.6" x2="64.55" y2="32.6" width="0.3" layer="16"/>
-<wire x1="64.55" y1="32.6" x2="64.6" y2="32.55" width="0.3" layer="16"/>
-<wire x1="65.212" y1="32.5" x2="63.8" y2="32.5" width="0.3" layer="1"/>
-<wire x1="63.8" y1="32.5" x2="63.7" y2="32.6" width="0.3" layer="1"/>
-<wire x1="33.45" y1="30.05" x2="33.45" y2="8.4" width="0.3" layer="16"/>
+<wire x1="75.962" y1="21.915" x2="74.465" y2="21.915" width="0.3" layer="1"/>
+<wire x1="74.45" y1="21.9" x2="74.465" y2="21.915" width="0.3" layer="1"/>
+<wire x1="74.45" y1="21.9" x2="73.8" y2="22.55" width="0.3" layer="16"/>
+<wire x1="73.8" y1="22.55" x2="63.4" y2="22.55" width="0.3" layer="16"/>
+<wire x1="51.85" y1="11" x2="39.05" y2="11" width="0.3" layer="16"/>
+<wire x1="39.05" y1="11" x2="34.83" y2="6.78" width="0.3" layer="16"/>
+<wire x1="34.83" y1="6.78" x2="34.83" y2="5.38" width="0.3" layer="16"/>
+<wire x1="63.4" y1="22.55" x2="51.85" y2="11" width="0.3" layer="16"/>
+<contactref element="RN2" pad="3"/>
+<wire x1="76.585" y1="21.915" x2="75.962" y2="21.915" width="0.3" layer="1"/>
+<wire x1="78.5" y1="22.15" x2="76.82" y2="22.15" width="0.3" layer="1"/>
+<wire x1="76.82" y1="22.15" x2="76.585" y2="21.915" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON17">
 <contactref element="FRDM1" pad="PTC16"/>
 <contactref element="IC3" pad="11"/>
-<via x="74.3" y="41.5" extent="1-16" drill="0.35"/>
-<wire x1="76.012" y1="41.495" x2="74.305" y2="41.495" width="0.3" layer="1"/>
-<wire x1="74.305" y1="41.495" x2="74.3" y2="41.5" width="0.3" layer="1"/>
-<contactref element="RN3" pad="10"/>
-<via x="63.65" y="42.1" extent="1-16" drill="0.35"/>
-<wire x1="74.2" y1="41.4" x2="74.3" y2="41.5" width="0.3" layer="16"/>
-<wire x1="63.65" y1="42.1" x2="64.262" y2="42.1" width="0.3" layer="1"/>
-<wire x1="64.262" y1="42.1" x2="65.212" y2="43.05" width="0.3" layer="1"/>
-<wire x1="63.65" y1="42.1" x2="73.7" y2="42.1" width="0.3" layer="16"/>
-<wire x1="73.7" y1="42.1" x2="74.3" y2="41.5" width="0.3" layer="16"/>
-<wire x1="63.65" y1="42.1" x2="63.05" y2="42.1" width="0.3" layer="16"/>
-<wire x1="63.05" y1="42.1" x2="61.3" y2="43.85" width="0.3" layer="16"/>
+<via x="74.45" y="41.6" extent="1-16" drill="0.45"/>
+<wire x1="75.962" y1="41.595" x2="74.455" y2="41.595" width="0.3" layer="1"/>
+<wire x1="74.455" y1="41.595" x2="74.45" y2="41.6" width="0.3" layer="1"/>
+<via x="63.95" y="42.2" extent="1-16" drill="0.45"/>
+<wire x1="63.95" y1="42.2" x2="73.85" y2="42.2" width="0.3" layer="16"/>
+<wire x1="73.85" y1="42.2" x2="74.45" y2="41.6" width="0.3" layer="16"/>
+<wire x1="63.95" y1="42.2" x2="62.95" y2="42.2" width="0.3" layer="16"/>
+<wire x1="62.95" y1="42.2" x2="61.3" y2="43.85" width="0.3" layer="16"/>
 <wire x1="61.3" y1="43.85" x2="36.65" y2="43.85" width="0.3" layer="16"/>
 <via x="36.65" y="43.85" extent="1-16" drill="0.35"/>
 <wire x1="36.1" y1="48.56" x2="36.1" y2="44.4" width="0.3" layer="1"/>
 <wire x1="36.1" y1="44.4" x2="36.65" y2="43.85" width="0.3" layer="1"/>
+<contactref element="RN1" pad="4"/>
+<wire x1="75.962" y1="41.595" x2="76.605" y2="41.595" width="0.3" layer="1"/>
+<wire x1="75.962" y1="41.595" x2="77.795" y2="41.595" width="0.3" layer="1"/>
+<wire x1="77.795" y1="41.595" x2="78.5" y2="42.3" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON19">
 <contactref element="FRDM1" pad="PTA16"/>
 <contactref element="IC3" pad="13"/>
-<wire x1="76.012" y1="44.035" x2="74.265" y2="44.035" width="0.3" layer="1"/>
-<contactref element="RN3" pad="8"/>
-<via x="74.265" y="44.035" extent="1-16" drill="0.35"/>
-<wire x1="63.665" y1="44.735" x2="73.565" y2="44.735" width="0.3" layer="16"/>
-<wire x1="73.565" y1="44.735" x2="74.265" y2="44.035" width="0.3" layer="16"/>
-<via x="63.665" y="44.735" extent="1-16" drill="0.35"/>
+<wire x1="75.962" y1="44.135" x2="74.415" y2="44.135" width="0.3" layer="1"/>
+<via x="74.415" y="44.135" extent="1-16" drill="0.45"/>
+<wire x1="63.3" y1="44.8" x2="63.95" y2="44.8" width="0.3" layer="16"/>
+<wire x1="63.95" y1="44.8" x2="73.75" y2="44.8" width="0.3" layer="16"/>
+<wire x1="73.75" y1="44.8" x2="74.415" y2="44.135" width="0.3" layer="16"/>
 <wire x1="31.02" y1="48.56" x2="31.02" y2="46.63" width="0.3" layer="1"/>
 <wire x1="31.02" y1="46.63" x2="31.6" y2="46.05" width="0.3" layer="1"/>
-<wire x1="65.212" y1="44.65" x2="63.75" y2="44.65" width="0.3" layer="1"/>
-<wire x1="63.75" y1="44.65" x2="63.665" y2="44.735" width="0.3" layer="1"/>
-<wire x1="63.65" y1="44.75" x2="63.665" y2="44.735" width="0.3" layer="1"/>
 <via x="31.6" y="46.05" extent="1-16" drill="0.35"/>
-<wire x1="63.65" y1="44.75" x2="63.665" y2="44.735" width="0.3" layer="16"/>
-<wire x1="31.6" y1="46.05" x2="62.1" y2="46.05" width="0.3" layer="16"/>
-<wire x1="62.1" y1="46.05" x2="63.415" y2="44.735" width="0.3" layer="16"/>
-<wire x1="63.665" y1="44.735" x2="63.415" y2="44.735" width="0.3" layer="16"/>
+<wire x1="31.6" y1="46.05" x2="62.05" y2="46.05" width="0.3" layer="16"/>
+<wire x1="62.05" y1="46.05" x2="63.3" y2="44.8" width="0.3" layer="16"/>
+<via x="63.95" y="44.8" extent="1-16" drill="0.45"/>
+<contactref element="RN1" pad="2"/>
+<wire x1="76.365" y1="44.135" x2="75.962" y2="44.135" width="0.3" layer="1"/>
+<wire x1="78.5" y1="43.9" x2="76.6" y2="43.9" width="0.3" layer="1"/>
+<wire x1="76.6" y1="43.9" x2="76.365" y2="44.135" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON21">
 <contactref element="FRDM1" pad="PTE31"/>
 <contactref element="IC3" pad="3"/>
-<contactref element="RN3" pad="5"/>
-<wire x1="67.588" y1="45.45" x2="69.2" y2="45.45" width="0.3" layer="1"/>
-<via x="69.2" y="45.45" extent="1-16" drill="0.35"/>
-<wire x1="70.588" y1="45.305" x2="69.345" y2="45.305" width="0.3" layer="1"/>
-<wire x1="69.345" y1="45.305" x2="69.2" y2="45.45" width="0.3" layer="1"/>
+<via x="69.15" y="45.4" extent="1-16" drill="0.45"/>
+<wire x1="70.538" y1="45.405" x2="69.155" y2="45.405" width="0.3" layer="1"/>
+<wire x1="69.155" y1="45.405" x2="69.15" y2="45.4" width="0.3" layer="1"/>
 <wire x1="25.94" y1="48.56" x2="27.85" y2="46.65" width="0.3" layer="16"/>
 <wire x1="27.85" y1="46.65" x2="62.25" y2="46.65" width="0.3" layer="16"/>
-<wire x1="62.25" y1="46.65" x2="63.45" y2="45.45" width="0.3" layer="16"/>
-<wire x1="69.2" y1="45.45" x2="63.45" y2="45.45" width="0.3" layer="16"/>
+<wire x1="62.25" y1="46.65" x2="63.5" y2="45.4" width="0.3" layer="16"/>
+<wire x1="69.15" y1="45.4" x2="63.5" y2="45.4" width="0.3" layer="16"/>
+<contactref element="RN4" pad="8"/>
+<wire x1="67.8" y1="44.7" x2="68.5" y2="45.4" width="0.3" layer="1"/>
+<wire x1="68.5" y1="45.4" x2="69.15" y2="45.4" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON23">
 <contactref element="FRDM1" pad="PTD7"/>
 <contactref element="IC3" pad="5"/>
-<contactref element="RN3" pad="3"/>
-<via x="69.25" y="42.8" extent="1-16" drill="0.35"/>
-<wire x1="67.588" y1="43.85" x2="68.2" y2="43.85" width="0.3" layer="1"/>
-<wire x1="68.2" y1="43.85" x2="69.25" y2="42.8" width="0.3" layer="1"/>
-<wire x1="69.2" y1="42.75" x2="69.25" y2="42.8" width="0.3" layer="16"/>
-<wire x1="70.588" y1="42.765" x2="69.285" y2="42.765" width="0.3" layer="1"/>
-<wire x1="69.285" y1="42.765" x2="69.25" y2="42.8" width="0.3" layer="1"/>
+<via x="69.15" y="42.9" extent="1-16" drill="0.45"/>
+<wire x1="70.538" y1="42.865" x2="69.185" y2="42.865" width="0.3" layer="1"/>
+<wire x1="69.185" y1="42.865" x2="69.15" y2="42.9" width="0.3" layer="1"/>
 <wire x1="18.32" y1="48.56" x2="18.32" y2="47.73" width="0.3" layer="16"/>
-<wire x1="18.32" y1="47.73" x2="20.45" y2="45.6" width="0.3" layer="16"/>
-<wire x1="69.25" y1="42.8" x2="63.1" y2="42.8" width="0.3" layer="16"/>
-<wire x1="63.1" y1="42.8" x2="61.5" y2="44.4" width="0.3" layer="16"/>
-<wire x1="61.5" y1="44.4" x2="31.4" y2="44.4" width="0.3" layer="16"/>
-<wire x1="31.4" y1="44.4" x2="30.2" y2="45.6" width="0.3" layer="16"/>
-<wire x1="30.2" y1="45.6" x2="20.45" y2="45.6" width="0.3" layer="16"/>
+<wire x1="18.32" y1="47.73" x2="20.1" y2="45.95" width="0.3" layer="16"/>
+<wire x1="20.1" y1="45.95" x2="26.75" y2="45.95" width="0.3" layer="16"/>
+<wire x1="69.15" y1="42.9" x2="63" y2="42.9" width="0.3" layer="16"/>
+<wire x1="63" y1="42.9" x2="61.5" y2="44.4" width="0.3" layer="16"/>
+<wire x1="61.5" y1="44.4" x2="31.3" y2="44.4" width="0.3" layer="16"/>
+<wire x1="31.3" y1="44.4" x2="30.15" y2="45.55" width="0.3" layer="16"/>
+<wire x1="30.15" y1="45.55" x2="27.15" y2="45.55" width="0.3" layer="16"/>
+<wire x1="27.15" y1="45.55" x2="26.75" y2="45.95" width="0.3" layer="16"/>
+<contactref element="RN4" pad="6"/>
+<wire x1="67.8" y1="43.1" x2="68.95" y2="43.1" width="0.3" layer="1"/>
+<wire x1="68.95" y1="43.1" x2="69.15" y2="42.9" width="0.3" layer="1"/>
 </signal>
 <signal name="EXPAN1">
 <contactref element="FRDM1" pad="PTC4"/>
 <contactref element="IC6" pad="8"/>
-<wire x1="55.15" y1="48.56" x2="55.15" y2="42.6" width="0.4" layer="1"/>
-<wire x1="55.575" y1="35.038" x2="55.575" y2="42.175" width="0.4" layer="1"/>
-<wire x1="55.575" y1="42.175" x2="55.15" y2="42.6" width="0.4" layer="1"/>
+<wire x1="55.15" y1="47.7" x2="55.15" y2="48.56" width="0.4" layer="1"/>
+<wire x1="59.936" y1="39.7944125" x2="59.936" y2="42.914" width="0.4" layer="1"/>
+<wire x1="67.7054125" y1="32.025" x2="59.936" y2="39.7944125" width="0.4" layer="1"/>
+<wire x1="67.7054125" y1="32.025" x2="70.112" y2="32.025" width="0.4" layer="1"/>
+<wire x1="55.15" y1="47.7" x2="59.936" y2="42.914" width="0.4" layer="1"/>
 </signal>
 <signal name="TV_RELAY">
 <contactref element="FRDM1" pad="D12"/>
 <contactref element="IC6" pad="11"/>
 <wire x1="31.02" y1="51.1" x2="31.15" y2="51.1" width="0.4" layer="1"/>
 <wire x1="31.15" y1="51.1" x2="32.3" y2="49.95" width="0.4" layer="1"/>
-<wire x1="32.3" y1="49.95" x2="32.3" y2="43.6" width="0.4" layer="1"/>
-<via x="53.3" y="39.6" extent="1-16" drill="0.45"/>
-<wire x1="53.3" y1="39.6" x2="53.2" y2="39.7" width="0.4" layer="16"/>
-<wire x1="53.2" y1="39.7" x2="47.25" y2="39.7" width="0.4" layer="16"/>
-<wire x1="47.25" y1="39.7" x2="45.35" y2="41.6" width="0.4" layer="16"/>
-<via x="33.2" y="42.7" extent="1-16" drill="0.35"/>
-<wire x1="32.3" y1="43.6" x2="33.2" y2="42.7" width="0.4" layer="1"/>
-<wire x1="53.625" y1="35.038" x2="53.625" y2="39.275" width="0.4" layer="1"/>
-<wire x1="53.625" y1="39.275" x2="53.3" y2="39.6" width="0.4" layer="1"/>
-<wire x1="33.2" y1="42.7" x2="38.2" y2="42.7" width="0.4" layer="16"/>
-<wire x1="38.2" y1="42.7" x2="39.3" y2="41.6" width="0.4" layer="16"/>
-<wire x1="39.3" y1="41.6" x2="45.35" y2="41.6" width="0.4" layer="16"/>
+<wire x1="32.3" y1="49.95" x2="32.3" y2="43.5" width="0.4" layer="1"/>
+<via x="59.9" y="37.65" extent="1-16" drill="0.45"/>
+<wire x1="54.3" y1="41.55" x2="39.3" y2="41.55" width="0.4" layer="16"/>
+<wire x1="39.3" y1="41.55" x2="38.2" y2="42.65" width="0.4" layer="16"/>
+<wire x1="38.2" y1="42.65" x2="33.15" y2="42.65" width="0.4" layer="16"/>
+<via x="33.15" y="42.65" extent="1-16" drill="0.45"/>
+<wire x1="32.3" y1="43.5" x2="33.15" y2="42.65" width="0.4" layer="1"/>
+<wire x1="54.3" y1="41.55" x2="55" y2="40.85" width="0.4" layer="16"/>
+<wire x1="70.112" y1="30.075" x2="67.46953125" y2="30.075" width="0.4" layer="1"/>
+<wire x1="67.46953125" y1="30.075" x2="59.89453125" y2="37.65" width="0.4" layer="1"/>
+<wire x1="59.9" y1="37.65" x2="59.89453125" y2="37.65" width="0.4" layer="1"/>
+<wire x1="59.9" y1="37.65" x2="56.7" y2="40.85" width="0.4" layer="16"/>
+<wire x1="55" y1="40.85" x2="56.7" y2="40.85" width="0.4" layer="16"/>
 </signal>
 <signal name="PLUNGER_CAL_LED">
 <contactref element="FRDM1" pad="PTE23"/>
 <contactref element="IC6" pad="14"/>
-<wire x1="53.625" y1="29.162" x2="53.625" y2="26.625" width="0.3" layer="1"/>
-<wire x1="57.69" y1="5.38" x2="57.69" y2="5.76" width="0.3" layer="1"/>
-<wire x1="57.69" y1="5.76" x2="55.1" y2="8.35" width="0.3" layer="1"/>
-<wire x1="55.1" y1="8.35" x2="55.1" y2="11.3" width="0.3" layer="1"/>
-<wire x1="53.625" y1="26.625" x2="53.1" y2="26.1" width="0.3" layer="1"/>
-<wire x1="53.1" y1="26.1" x2="53.1" y2="13.3" width="0.3" layer="1"/>
-<wire x1="53.1" y1="13.3" x2="55.1" y2="11.3" width="0.3" layer="1"/>
+<wire x1="57.69" y1="5.38" x2="57.69" y2="6.34" width="0.4" layer="1"/>
+<wire x1="57.69" y1="6.34" x2="58.55" y2="7.2" width="0.4" layer="1"/>
+<wire x1="58.55" y1="7.2" x2="64.4" y2="7.2" width="0.4" layer="1"/>
+<wire x1="64.4" y1="7.2" x2="67.85" y2="3.75" width="0.4" layer="1"/>
+<via x="73.75" y="3.75" extent="1-16" drill="0.35"/>
+<wire x1="73.75" y1="3.75" x2="74.3" y2="3.75" width="0.4" layer="16"/>
+<wire x1="77.55" y1="7" x2="77.55" y2="29.8" width="0.4" layer="16"/>
+<via x="77.55" y="29.8" extent="1-16" drill="0.45"/>
+<wire x1="67.85" y1="3.75" x2="73.75" y2="3.75" width="0.4" layer="1"/>
+<wire x1="74.3" y1="3.75" x2="77.55" y2="7" width="0.4" layer="16"/>
+<wire x1="75.988" y1="30.075" x2="77.275" y2="30.075" width="0.4" layer="1"/>
+<wire x1="77.275" y1="30.075" x2="77.55" y2="29.8" width="0.4" layer="1"/>
 </signal>
 <signal name="BUTTON18">
 <contactref element="FRDM1" pad="PTC17"/>
 <contactref element="IC3" pad="12"/>
-<via x="74.3" y="42.75" extent="1-16" drill="0.35"/>
-<wire x1="76.012" y1="42.765" x2="74.435" y2="42.765" width="0.3" layer="1"/>
-<wire x1="74.435" y1="42.765" x2="74.3" y2="42.75" width="0.3" layer="1"/>
-<contactref element="RN3" pad="9"/>
-<wire x1="63.7" y1="43.45" x2="64.15" y2="43.45" width="0.3" layer="1"/>
-<wire x1="64.15" y1="43.45" x2="64.55" y2="43.85" width="0.3" layer="1"/>
-<wire x1="65.212" y1="43.85" x2="64.55" y2="43.85" width="0.3" layer="1"/>
-<via x="63.7" y="43.45" extent="1-16" drill="0.35"/>
-<wire x1="63.7" y1="43.45" x2="73.6" y2="43.45" width="0.3" layer="16"/>
-<wire x1="73.6" y1="43.45" x2="74.3" y2="42.75" width="0.3" layer="16"/>
-<wire x1="63.7" y1="43.45" x2="63.2" y2="43.45" width="0.3" layer="16"/>
-<wire x1="63.2" y1="43.45" x2="61.7" y2="44.95" width="0.3" layer="16"/>
+<via x="74.45" y="42.85" extent="1-16" drill="0.45"/>
+<wire x1="75.962" y1="42.865" x2="74.585" y2="42.865" width="0.3" layer="1"/>
+<wire x1="74.585" y1="42.865" x2="74.45" y2="42.85" width="0.3" layer="1"/>
+<via x="63.95" y="43.5" extent="1-16" drill="0.45"/>
+<wire x1="73.8" y1="43.5" x2="63.95" y2="43.5" width="0.3" layer="16"/>
+<wire x1="73.8" y1="43.5" x2="74.45" y2="42.85" width="0.3" layer="16"/>
+<wire x1="63.95" y1="43.5" x2="63.15" y2="43.5" width="0.3" layer="16"/>
+<wire x1="63.15" y1="43.5" x2="61.7" y2="44.95" width="0.3" layer="16"/>
 <wire x1="61.7" y1="44.95" x2="34.1" y2="44.95" width="0.3" layer="16"/>
 <via x="34.1" y="44.95" extent="1-16" drill="0.35"/>
 <wire x1="33.56" y1="48.56" x2="33.56" y2="45.49" width="0.3" layer="1"/>
 <wire x1="33.56" y1="45.49" x2="34.1" y2="44.95" width="0.3" layer="1"/>
+<contactref element="RN1" pad="3"/>
+<wire x1="76.635" y1="42.815" x2="76.012" y2="42.815" width="0.3" layer="1"/>
+<wire x1="75.962" y1="42.865" x2="76.012" y2="42.815" width="0.3" layer="1"/>
+<wire x1="78.5" y1="43.1" x2="76.92" y2="43.1" width="0.3" layer="1"/>
+<wire x1="76.92" y1="43.1" x2="76.635" y2="42.815" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON20">
 <contactref element="FRDM1" pad="PTA17"/>
 <contactref element="IC3" pad="14"/>
-<contactref element="RN3" pad="7"/>
-<wire x1="76.012" y1="45.305" x2="74.355" y2="45.305" width="0.3" layer="1"/>
-<wire x1="74.355" y1="45.305" x2="74.35" y2="45.3" width="0.3" layer="1"/>
-<via x="74.35" y="45.3" extent="1-16" drill="0.35"/>
-<via x="63.65" y="46.15" extent="1-16" drill="0.35"/>
-<wire x1="74.2" y1="45.45" x2="74.35" y2="45.3" width="0.3" layer="16"/>
-<wire x1="63.65" y1="46.15" x2="73.5" y2="46.15" width="0.3" layer="16"/>
-<wire x1="73.5" y1="46.15" x2="74.35" y2="45.3" width="0.3" layer="16"/>
-<wire x1="63.65" y1="46.15" x2="64.512" y2="46.15" width="0.3" layer="1"/>
-<wire x1="64.512" y1="46.15" x2="65.212" y2="45.45" width="0.3" layer="1"/>
+<wire x1="75.962" y1="45.405" x2="74.455" y2="45.405" width="0.3" layer="1"/>
+<wire x1="74.455" y1="45.405" x2="74.45" y2="45.4" width="0.3" layer="1"/>
+<via x="74.45" y="45.4" extent="1-16" drill="0.45"/>
+<via x="63.65" y="46.2" extent="1-16" drill="0.45"/>
+<wire x1="73.8" y1="46.05" x2="63.8" y2="46.05" width="0.3" layer="16"/>
+<wire x1="63.65" y1="46.2" x2="63.8" y2="46.05" width="0.3" layer="16"/>
+<wire x1="74.45" y1="45.4" x2="73.8" y2="46.05" width="0.3" layer="16"/>
 <wire x1="28.48" y1="48.56" x2="28.48" y2="47.97" width="0.3" layer="16"/>
 <wire x1="28.48" y1="47.97" x2="29.3" y2="47.15" width="0.3" layer="16"/>
-<wire x1="29.3" y1="47.15" x2="62.65" y2="47.15" width="0.3" layer="16"/>
-<wire x1="62.65" y1="47.15" x2="63.65" y2="46.15" width="0.3" layer="16"/>
+<wire x1="29.3" y1="47.15" x2="62.7" y2="47.15" width="0.3" layer="16"/>
+<wire x1="62.7" y1="47.15" x2="63.65" y2="46.2" width="0.3" layer="16"/>
+<contactref element="RN1" pad="1"/>
+<wire x1="75.962" y1="45.405" x2="76.595" y2="45.405" width="0.3" layer="1"/>
+<wire x1="78.5" y1="44.7" x2="77.795" y2="45.405" width="0.3" layer="1"/>
+<wire x1="77.795" y1="45.405" x2="75.962" y2="45.405" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON22">
 <contactref element="FRDM1" pad="PTD6"/>
 <contactref element="IC3" pad="4"/>
-<contactref element="RN3" pad="4"/>
-<wire x1="70.573" y1="44.05" x2="70.588" y2="44.035" width="0.3" layer="1"/>
-<wire x1="70.573" y1="44.05" x2="69.95" y2="44.05" width="0.3" layer="1"/>
-<via x="69.2" y="44.1" extent="1-16" drill="0.35"/>
-<wire x1="67.588" y1="44.65" x2="68.65" y2="44.65" width="0.3" layer="1"/>
-<wire x1="68.65" y1="44.65" x2="69.2" y2="44.1" width="0.3" layer="1"/>
-<wire x1="70.588" y1="44.035" x2="69.265" y2="44.035" width="0.3" layer="1"/>
-<wire x1="69.265" y1="44.035" x2="69.2" y2="44.1" width="0.3" layer="1"/>
+<via x="69.15" y="44.2" extent="1-16" drill="0.45"/>
+<wire x1="70.538" y1="44.135" x2="69.215" y2="44.135" width="0.3" layer="1"/>
+<wire x1="69.215" y1="44.135" x2="69.15" y2="44.2" width="0.3" layer="1"/>
 <wire x1="20.86" y1="48.56" x2="20.86" y2="47.34" width="0.3" layer="16"/>
-<wire x1="20.86" y1="47.34" x2="22.1" y2="46.1" width="0.3" layer="16"/>
-<wire x1="69.2" y1="44.1" x2="63.3" y2="44.1" width="0.3" layer="16"/>
-<wire x1="63.3" y1="44.1" x2="61.9" y2="45.5" width="0.3" layer="16"/>
+<wire x1="20.86" y1="47.34" x2="21.6" y2="46.6" width="0.3" layer="16"/>
+<wire x1="21.6" y1="46.6" x2="27.05" y2="46.6" width="0.3" layer="16"/>
+<wire x1="27.05" y1="46.6" x2="27.55" y2="46.1" width="0.3" layer="16"/>
+<wire x1="69.15" y1="44.2" x2="63.2" y2="44.2" width="0.3" layer="16"/>
+<wire x1="63.2" y1="44.2" x2="61.9" y2="45.5" width="0.3" layer="16"/>
 <wire x1="61.9" y1="45.5" x2="31.1" y2="45.5" width="0.3" layer="16"/>
 <wire x1="31.1" y1="45.5" x2="30.5" y2="46.1" width="0.3" layer="16"/>
-<wire x1="30.5" y1="46.1" x2="22.1" y2="46.1" width="0.3" layer="16"/>
+<wire x1="30.5" y1="46.1" x2="27.55" y2="46.1" width="0.3" layer="16"/>
+<contactref element="RN4" pad="7"/>
+<wire x1="67.8" y1="43.9" x2="68.85" y2="43.9" width="0.3" layer="1"/>
+<wire x1="68.85" y1="43.9" x2="69.15" y2="44.2" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON24">
 <contactref element="FRDM1" pad="D15"/>
 <contactref element="IC3" pad="6"/>
-<contactref element="RN3" pad="2"/>
-<via x="69.2" y="41.45" extent="1-16" drill="0.35"/>
-<wire x1="67.588" y1="43.05" x2="67.6" y2="43.05" width="0.3" layer="1"/>
-<wire x1="67.6" y1="43.05" x2="69.2" y2="41.45" width="0.3" layer="1"/>
-<wire x1="70.588" y1="41.495" x2="69.245" y2="41.495" width="0.3" layer="1"/>
-<wire x1="69.245" y1="41.495" x2="69.2" y2="41.45" width="0.3" layer="1"/>
-<wire x1="69.2" y1="41.45" x2="69.1" y2="41.35" width="0.3" layer="16"/>
+<via x="69.15" y="41.55" extent="1-16" drill="0.45"/>
+<wire x1="70.538" y1="41.595" x2="69.195" y2="41.595" width="0.3" layer="1"/>
+<wire x1="69.195" y1="41.595" x2="69.15" y2="41.55" width="0.3" layer="1"/>
 <wire x1="18.32" y1="51.1" x2="17.65" y2="51.1" width="0.3" layer="16"/>
-<wire x1="19.15" y1="45.1" x2="16.9" y2="47.35" width="0.3" layer="16"/>
+<wire x1="26.35" y1="45.35" x2="18.9" y2="45.35" width="0.3" layer="16"/>
+<wire x1="18.9" y1="45.35" x2="16.9" y2="47.35" width="0.3" layer="16"/>
 <wire x1="16.9" y1="47.35" x2="16.9" y2="50.35" width="0.3" layer="16"/>
 <wire x1="16.9" y1="50.35" x2="17.65" y2="51.1" width="0.3" layer="16"/>
-<wire x1="69.1" y1="41.35" x2="63.05" y2="41.35" width="0.3" layer="16"/>
-<wire x1="63.05" y1="41.35" x2="61.1" y2="43.3" width="0.3" layer="16"/>
-<wire x1="61.1" y1="43.3" x2="31.7" y2="43.3" width="0.3" layer="16"/>
-<wire x1="31.7" y1="43.3" x2="29.9" y2="45.1" width="0.3" layer="16"/>
-<wire x1="29.9" y1="45.1" x2="19.15" y2="45.1" width="0.3" layer="16"/>
+<wire x1="69.15" y1="41.55" x2="62.85" y2="41.55" width="0.3" layer="16"/>
+<wire x1="62.85" y1="41.55" x2="61.1" y2="43.3" width="0.3" layer="16"/>
+<wire x1="61.1" y1="43.3" x2="36.1" y2="43.3" width="0.3" layer="16"/>
+<wire x1="36.1" y1="43.3" x2="35.6" y2="43.8" width="0.3" layer="16"/>
+<wire x1="35.6" y1="43.8" x2="31" y2="43.8" width="0.3" layer="16"/>
+<wire x1="31" y1="43.8" x2="29.9" y2="44.9" width="0.3" layer="16"/>
+<wire x1="29.9" y1="44.9" x2="26.8" y2="44.9" width="0.3" layer="16"/>
+<wire x1="26.8" y1="44.9" x2="26.35" y2="45.35" width="0.3" layer="16"/>
+<contactref element="RN4" pad="5"/>
+<wire x1="67.8" y1="42.3" x2="68.55" y2="41.55" width="0.3" layer="1"/>
+<wire x1="68.55" y1="41.55" x2="69.15" y2="41.55" width="0.3" layer="1"/>
 </signal>
 <signal name="EXPAN2">
 <contactref element="FRDM1" pad="PTC3"/>
 <contactref element="IC6" pad="6"/>
-<wire x1="57.69" y1="48.56" x2="57.69" y2="47.01" width="0.4" layer="1"/>
-<wire x1="56.875" y1="35.038" x2="56.875" y2="46.195" width="0.4" layer="1"/>
-<wire x1="56.875" y1="46.195" x2="57.69" y2="47.01" width="0.4" layer="1"/>
+<wire x1="57.69" y1="48.56" x2="57.69" y2="47.48" width="0.4" layer="1"/>
+<wire x1="70.112" y1="33.325" x2="70.11" y2="33.323" width="0.4" layer="1"/>
+<wire x1="70.11" y1="33.323" x2="68.498" y2="33.323" width="0.4" layer="1"/>
+<wire x1="68.498" y1="33.323" x2="61.49" y2="40.331" width="0.4" layer="1"/>
+<wire x1="61.49" y1="43.68" x2="57.69" y2="47.48" width="0.4" layer="1"/>
+<wire x1="61.49" y1="40.331" x2="61.49" y2="43.68" width="0.4" layer="1"/>
 </signal>
 <signal name="EXPAN4">
 <contactref element="FRDM1" pad="D1"/>
 <contactref element="IC6" pad="5"/>
-<wire x1="58.95" y1="46.7" x2="58.95" y2="49.82" width="0.4" layer="1"/>
+<wire x1="58.95" y1="47.45" x2="58.95" y2="49.82" width="0.4" layer="1"/>
 <wire x1="58.95" y1="49.82" x2="60.23" y2="51.1" width="0.4" layer="1"/>
-<wire x1="57.525" y1="35.038" x2="57.525" y2="45.275" width="0.4" layer="1"/>
-<wire x1="57.525" y1="45.275" x2="58.95" y2="46.7" width="0.4" layer="1"/>
+<wire x1="58.95" y1="47.45" x2="62.253" y2="44.147" width="0.4" layer="1"/>
+<wire x1="62.253" y1="40.66329375" x2="62.253" y2="44.147" width="0.4" layer="1"/>
+<wire x1="68.94129375" y1="33.975" x2="62.253" y2="40.66329375" width="0.4" layer="1"/>
+<wire x1="68.94129375" y1="33.975" x2="70.112" y2="33.975" width="0.4" layer="1"/>
 </signal>
 <signal name="KNOCKER">
 <contactref element="FRDM1" pad="D6"/>
 <contactref element="IC6" pad="9"/>
-<wire x1="47.53" y1="51.1" x2="47.1" y2="51.1" width="0.4" layer="1"/>
-<wire x1="47.1" y1="51.1" x2="46.25" y2="50.25" width="0.4" layer="1"/>
-<wire x1="46.25" y1="50.25" x2="46.25" y2="41.8" width="0.4" layer="1"/>
-<via x="54.35" y="40.95" extent="1-16" drill="0.45"/>
-<wire x1="54.35" y1="40.95" x2="54.3" y2="41" width="0.4" layer="16"/>
-<wire x1="54.3" y1="41" x2="47.05" y2="41" width="0.4" layer="16"/>
-<via x="47.05" y="41" extent="1-16" drill="0.35"/>
-<wire x1="46.25" y1="41.8" x2="47.05" y2="41" width="0.4" layer="1"/>
-<wire x1="54.925" y1="35.038" x2="54.925" y2="40.375" width="0.4" layer="1"/>
-<wire x1="54.925" y1="40.375" x2="54.35" y2="40.95" width="0.4" layer="1"/>
+<wire x1="48.8" y1="49.83" x2="47.53" y2="51.1" width="0.4" layer="1"/>
+<via x="59.9" y="38.8" extent="1-16" drill="0.45"/>
+<wire x1="59.9" y1="38.8" x2="57.15" y2="41.55" width="0.4" layer="16"/>
+<wire x1="57.15" y1="41.55" x2="55.4" y2="41.55" width="0.4" layer="16"/>
+<via x="55.4" y="41.55" extent="1-16" drill="0.45"/>
+<wire x1="59.9" y1="38.8" x2="59.9" y2="38.78511875" width="0.4" layer="1"/>
+<wire x1="67.31011875" y1="31.375" x2="59.9" y2="38.78511875" width="0.4" layer="1"/>
+<wire x1="67.31011875" y1="31.375" x2="70.112" y2="31.375" width="0.4" layer="1"/>
+<wire x1="55.4" y1="41.55" x2="49.85" y2="47.1" width="0.4" layer="1"/>
+<wire x1="49.04755" y1="47.1" x2="48.8" y2="47.34755" width="0.4" layer="1"/>
+<wire x1="49.85" y1="47.1" x2="49.04755" y2="47.1" width="0.4" layer="1"/>
+<wire x1="48.8" y1="47.34755" x2="48.8" y2="49.83" width="0.4" layer="1"/>
 </signal>
 <signal name="PLUNGER_CAL_BTN">
 <contactref element="FRDM1" pad="PTE29"/>
 <contactref element="IC6" pad="15"/>
-<wire x1="54.275" y1="29.162" x2="54.275" y2="26.275" width="0.3" layer="1"/>
-<wire x1="60.23" y1="5.38" x2="60.23" y2="6.02" width="0.3" layer="1"/>
-<wire x1="60.23" y1="6.02" x2="59" y2="7.25" width="0.3" layer="1"/>
-<wire x1="59" y1="7.25" x2="57.05" y2="7.25" width="0.3" layer="1"/>
-<wire x1="57.05" y1="7.25" x2="55.85" y2="8.45" width="0.3" layer="1"/>
-<wire x1="55.85" y1="8.45" x2="55.85" y2="11.3" width="0.3" layer="1"/>
-<wire x1="54.275" y1="26.275" x2="53.7" y2="25.7" width="0.3" layer="1"/>
-<wire x1="53.7" y1="25.7" x2="53.7" y2="13.45" width="0.3" layer="1"/>
-<wire x1="53.7" y1="13.45" x2="55.85" y2="11.3" width="0.3" layer="1"/>
+<wire x1="60.23" y1="5.38" x2="61.51" y2="4.1" width="0.4" layer="1"/>
+<via x="74.65" y="2.85" extent="1-16" drill="0.35"/>
+<wire x1="74.65" y1="2.85" x2="78.3" y2="6.5" width="0.4" layer="16"/>
+<via x="78.3" y="31.55" extent="1-16" drill="0.45"/>
+<wire x1="78.3" y1="31.55" x2="77.45" y2="30.7" width="0.4" layer="1"/>
+<wire x1="76.013" y1="30.7" x2="75.988" y2="30.725" width="0.4" layer="1"/>
+<wire x1="61.51" y1="4.1" x2="66.15" y2="4.1" width="0.4" layer="1"/>
+<wire x1="66.15" y1="4.1" x2="67.4" y2="2.85" width="0.4" layer="1"/>
+<wire x1="67.4" y1="2.85" x2="74.65" y2="2.85" width="0.4" layer="1"/>
+<wire x1="78.3" y1="6.5" x2="78.3" y2="31.55" width="0.4" layer="16"/>
+<wire x1="77.45" y1="30.7" x2="76.013" y2="30.7" width="0.4" layer="1"/>
 </signal>
 <signal name="EXPAN3">
 <contactref element="FRDM1" pad="PTC0"/>
 <contactref element="IC6" pad="4"/>
-<wire x1="58.175" y1="35.038" x2="58.175" y2="38.275" width="0.4" layer="1"/>
-<wire x1="60.23" y1="48.56" x2="60.23" y2="40.33" width="0.4" layer="1"/>
-<wire x1="60.23" y1="40.33" x2="58.175" y2="38.275" width="0.4" layer="1"/>
+<wire x1="60.23" y1="48.56" x2="60.23" y2="47.46" width="0.4" layer="1"/>
+<wire x1="62.98" y1="44.71" x2="60.23" y2="47.46" width="0.4" layer="1"/>
+<wire x1="62.98" y1="44.71" x2="62.98" y2="40.9815875" width="0.4" layer="1"/>
+<wire x1="62.98" y1="40.9815875" x2="69.3365875" y2="34.625" width="0.4" layer="1"/>
+<wire x1="69.3365875" y1="34.625" x2="70.112" y2="34.625" width="0.4" layer="1"/>
 </signal>
 <signal name="BUTTON9">
 <contactref element="FRDM1" pad="PTE3"/>
-<wire x1="63.05" y1="30.3" x2="61.4" y2="31.95" width="0.3" layer="16"/>
-<wire x1="61.4" y1="31.95" x2="37.95" y2="31.95" width="0.3" layer="16"/>
-<wire x1="35.2" y1="29.2" x2="35.2" y2="11" width="0.3" layer="16"/>
-<wire x1="39.91" y1="5.38" x2="39.91" y2="6.29" width="0.3" layer="16"/>
-<contactref element="RN2" pad="2"/>
 <contactref element="IC2" pad="6"/>
-<via x="69.25" y="30.5" extent="1-16" drill="0.35"/>
-<wire x1="70.688" y1="30.545" x2="69.295" y2="30.545" width="0.3" layer="1"/>
-<wire x1="69.295" y1="30.545" x2="69.25" y2="30.5" width="0.3" layer="1"/>
-<wire x1="69.25" y1="30.5" x2="69.2" y2="30.5" width="0.3" layer="16"/>
-<wire x1="69.2" y1="30.5" x2="69" y2="30.3" width="0.3" layer="16"/>
-<wire x1="69" y1="30.3" x2="63.05" y2="30.3" width="0.3" layer="16"/>
-<wire x1="69.25" y1="30.5" x2="69.05" y2="30.5" width="0.3" layer="1"/>
-<wire x1="67.588" y1="31.7" x2="67.9" y2="31.7" width="0.3" layer="1"/>
-<wire x1="67.9" y1="31.7" x2="69.05" y2="30.55" width="0.3" layer="1"/>
-<wire x1="69.05" y1="30.5" x2="69.05" y2="30.55" width="0.3" layer="1"/>
-<wire x1="39.91" y1="6.29" x2="35.2" y2="11" width="0.3" layer="16"/>
-<wire x1="37.95" y1="31.95" x2="35.2" y2="29.2" width="0.3" layer="16"/>
+<via x="69.15" y="20.65" extent="1-16" drill="0.45"/>
+<wire x1="70.538" y1="20.645" x2="69.155" y2="20.645" width="0.3" layer="1"/>
+<wire x1="69.155" y1="20.645" x2="69.15" y2="20.65" width="0.3" layer="1"/>
+<wire x1="69.15" y1="20.65" x2="64.05" y2="20.65" width="0.3" layer="16"/>
+<wire x1="43.63" y1="9.1" x2="39.91" y2="5.38" width="0.3" layer="16"/>
+<wire x1="64.05" y1="20.65" x2="52.5" y2="9.1" width="0.3" layer="16"/>
+<wire x1="52.5" y1="9.1" x2="43.63" y2="9.1" width="0.3" layer="16"/>
+<contactref element="RN6" pad="5"/>
+<wire x1="67.8" y1="21.35" x2="68.5" y2="20.65" width="0.3" layer="1"/>
+<wire x1="68.5" y1="20.65" x2="69.15" y2="20.65" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON10">
 <contactref element="FRDM1" pad="PTE2"/>
-<via x="74.65" y="30.6" extent="1-16" drill="0.35"/>
-<via x="63.7" y="31.15" extent="1-16" drill="0.35"/>
-<wire x1="37.6" y1="32.5" x2="34.6" y2="29.5" width="0.3" layer="16"/>
-<wire x1="34.6" y1="29.5" x2="34.6" y2="10.6" width="0.3" layer="16"/>
-<wire x1="34.6" y1="10.6" x2="37.37" y2="7.83" width="0.3" layer="16"/>
-<wire x1="37.37" y1="5.38" x2="37.37" y2="7.83" width="0.3" layer="16"/>
+<via x="74.45" y="20.7" extent="1-16" drill="0.45"/>
+<via x="63.8" y="21.25" extent="1-16" drill="0.45"/>
 <contactref element="IC2" pad="11"/>
-<wire x1="37.6" y1="32.5" x2="61.6" y2="32.5" width="0.3" layer="16"/>
-<wire x1="61.6" y1="32.5" x2="62.95" y2="31.15" width="0.3" layer="16"/>
-<contactref element="RN2" pad="10"/>
-<wire x1="65.212" y1="31.7" x2="65.05" y2="31.7" width="0.3" layer="1"/>
-<wire x1="65.212" y1="31.7" x2="64.85" y2="31.7" width="0.3" layer="1"/>
-<wire x1="64.85" y1="31.7" x2="64.3" y2="31.15" width="0.3" layer="1"/>
-<wire x1="76.112" y1="30.545" x2="74.705" y2="30.545" width="0.3" layer="1"/>
-<wire x1="74.705" y1="30.545" x2="74.65" y2="30.6" width="0.3" layer="1"/>
-<wire x1="74.65" y1="30.6" x2="71" y2="30.6" width="0.3" layer="16"/>
-<wire x1="71" y1="30.6" x2="70.45" y2="31.15" width="0.3" layer="16"/>
-<wire x1="70.45" y1="31.15" x2="63.7" y2="31.15" width="0.3" layer="16"/>
-<wire x1="63.7" y1="31.15" x2="62.95" y2="31.15" width="0.3" layer="16"/>
-<wire x1="63.7" y1="31.15" x2="64.3" y2="31.15" width="0.3" layer="1"/>
+<wire x1="75.962" y1="20.645" x2="74.505" y2="20.645" width="0.3" layer="1"/>
+<wire x1="74.505" y1="20.645" x2="74.45" y2="20.7" width="0.3" layer="1"/>
+<wire x1="74.45" y1="20.7" x2="73.9" y2="21.25" width="0.3" layer="16"/>
+<wire x1="73.9" y1="21.25" x2="63.8" y2="21.25" width="0.3" layer="16"/>
+<wire x1="41.69" y1="9.7" x2="37.37" y2="5.38" width="0.3" layer="16"/>
+<wire x1="63.8" y1="21.25" x2="52.25" y2="9.7" width="0.3" layer="16"/>
+<wire x1="52.25" y1="9.7" x2="41.69" y2="9.7" width="0.3" layer="16"/>
+<contactref element="RN2" pad="4"/>
+<wire x1="75.962" y1="20.645" x2="76.605" y2="20.645" width="0.3" layer="1"/>
+<wire x1="75.962" y1="20.645" x2="77.795" y2="20.645" width="0.3" layer="1"/>
+<wire x1="77.795" y1="20.645" x2="78.5" y2="21.35" width="0.3" layer="1"/>
 </signal>
 <signal name="5V_PICO">
 <contactref element="FRDM1" pad="5V"/>
@@ -4295,295 +4461,286 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 <wire x1="37.37" y1="2.84" x2="37.37" y2="1.87" width="1" layer="16"/>
 <wire x1="37.37" y1="1.87" x2="36.65" y2="1.15" width="1" layer="16"/>
 <wire x1="36.65" y1="1.15" x2="7.2" y2="1.15" width="1" layer="16"/>
-<via x="1.8" y="32.65" extent="1-16" drill="1.2"/>
-<wire x1="1.81" y1="35.645" x2="1.81" y2="32.71" width="1" layer="1"/>
-<wire x1="1.81" y1="32.71" x2="1.8" y2="32.65" width="1" layer="1"/>
-<wire x1="1.8" y1="6.55" x2="7.2" y2="1.15" width="1" layer="16"/>
-<wire x1="1.8" y1="32.65" x2="1.8" y2="6.55" width="1" layer="16"/>
+<wire x1="0.55" y1="7.8" x2="0.55" y2="18.1" width="1" layer="16"/>
+<wire x1="2.3" y1="19.85" x2="2.3" y2="31.97" width="1" layer="16"/>
+<wire x1="2.3" y1="19.85" x2="0.55" y2="18.1" width="1" layer="16"/>
+<via x="2.3" y="31.97" extent="1-16" drill="1.2"/>
+<wire x1="0.55" y1="7.8" x2="7.2" y2="1.15" width="1" layer="16"/>
+<wire x1="2.3" y1="31.97" x2="2.31" y2="31.98" width="1" layer="1"/>
+<wire x1="2.31" y1="31.98" x2="2.31" y2="35.01" width="1" layer="1"/>
 </signal>
 <signal name="PLUNGER_SDA">
 <contactref element="RASPBERRY_PI_PICO" pad="GP10"/>
 <contactref element="FRDM1" pad="PTE20"/>
-<wire x1="50.07" y1="8.43" x2="46.5" y2="12" width="0.4" layer="1"/>
-<wire x1="46.5" y1="12" x2="36.85" y2="12" width="0.4" layer="1"/>
-<wire x1="50.07" y1="5.38" x2="50.07" y2="8.43" width="0.4" layer="1"/>
-<wire x1="34.83" y1="16.595" x2="34.83" y2="14.02" width="0.4" layer="1"/>
-<wire x1="34.83" y1="14.02" x2="36.85" y2="12" width="0.4" layer="1"/>
+<wire x1="50.07" y1="5.38" x2="46.4" y2="9.05" width="0.4" layer="1"/>
+<wire x1="46.4" y1="9.05" x2="40.8" y2="9.05" width="0.4" layer="1"/>
+<wire x1="35.33" y1="17.23" x2="35.33" y2="14.52" width="0.4" layer="1"/>
+<wire x1="35.33" y1="14.52" x2="40.8" y2="9.05" width="0.4" layer="1"/>
 </signal>
 <signal name="PLUNGER_IRQ1_SCL">
 <contactref element="RASPBERRY_PI_PICO" pad="GP11"/>
 <contactref element="FRDM1" pad="PTE21"/>
 <contactref element="FRDM1" pad="D10"/>
-<wire x1="37.37" y1="16.595" x2="37.37" y2="13.68" width="0.4" layer="1"/>
-<wire x1="52.61" y1="5.38" x2="52.61" y2="7.14" width="0.4" layer="1"/>
-<wire x1="52.61" y1="7.14" x2="47.05" y2="12.7" width="0.4" layer="1"/>
-<wire x1="47.05" y1="12.7" x2="38.35" y2="12.7" width="0.4" layer="1"/>
-<wire x1="37.37" y1="13.68" x2="38.35" y2="12.7" width="0.4" layer="1"/>
+<wire x1="37.87" y1="17.23" x2="37.87" y2="14.93" width="0.4" layer="1"/>
+<wire x1="52.61" y1="5.38" x2="52.61" y2="5.39" width="0.4" layer="1"/>
+<wire x1="52.61" y1="5.39" x2="48.2" y2="9.8" width="0.4" layer="1"/>
+<wire x1="48.2" y1="9.8" x2="43" y2="9.8" width="0.4" layer="1"/>
+<wire x1="37.87" y1="14.93" x2="43" y2="9.8" width="0.4" layer="1"/>
 <wire x1="36.1" y1="51.1" x2="36.35" y2="51.1" width="0.4" layer="1"/>
-<wire x1="36.35" y1="51.1" x2="37.35" y2="50.1" width="0.4" layer="1"/>
-<wire x1="37.35" y1="50.1" x2="37.35" y2="41.2" width="0.4" layer="1"/>
-<via x="36.1" y="39.95" extent="1-16" drill="0.45"/>
-<wire x1="36.1" y1="39.95" x2="36.1" y2="35.8" width="0.4" layer="16"/>
-<wire x1="36.1" y1="35.8" x2="31.3" y2="31" width="0.4" layer="16"/>
-<wire x1="31.3" y1="31" x2="31.3" y2="20.55" width="0.4" layer="16"/>
-<via x="31.3" y="20.55" extent="1-16" drill="0.45"/>
-<wire x1="32.8" y1="19.6" x2="35.55" y2="19.6" width="0.4" layer="1"/>
-<wire x1="35.55" y1="19.6" x2="37.37" y2="17.78" width="0.4" layer="1"/>
-<wire x1="37.37" y1="16.595" x2="37.37" y2="17.78" width="0.4" layer="1"/>
-<wire x1="37.35" y1="41.2" x2="36.1" y2="39.95" width="0.4" layer="1"/>
-<wire x1="32.8" y1="19.6" x2="32.25" y2="19.6" width="0.35" layer="1"/>
-<wire x1="32.25" y1="19.6" x2="31.3" y2="20.55" width="0.35" layer="1"/>
+<wire x1="37.35" y1="50.1" x2="36.35" y2="51.1" width="0.4" layer="1"/>
+<via x="37.9" y="28.55" extent="1-16" drill="0.45"/>
+<via x="37.85" y="21.05" extent="1-16" drill="0.45"/>
+<wire x1="37.87" y1="17.23" x2="37.87" y2="21.03" width="0.4" layer="1"/>
+<wire x1="37.87" y1="21.03" x2="37.85" y2="21.05" width="0.4" layer="1"/>
+<wire x1="37.9" y1="28.55" x2="37.85" y2="28.5" width="0.4" layer="16"/>
+<wire x1="37.85" y1="28.5" x2="37.85" y2="21.05" width="0.4" layer="16"/>
+<wire x1="37.9" y1="28.55" x2="41.35" y2="32" width="0.4" layer="1"/>
+<wire x1="41.35" y1="32" x2="51.95" y2="32" width="0.4" layer="1"/>
+<wire x1="51.95" y1="32" x2="52.6" y2="32.65" width="0.4" layer="1"/>
+<wire x1="50.3" y1="39.3" x2="41.55" y2="39.3" width="0.4" layer="1"/>
+<wire x1="41.55" y1="39.3" x2="37.35" y2="43.5" width="0.4" layer="1"/>
+<wire x1="37.35" y1="43.5" x2="37.35" y2="50.1" width="0.4" layer="1"/>
+<wire x1="52.6" y1="32.65" x2="52.6" y2="37" width="0.4" layer="1"/>
+<wire x1="52.6" y1="37" x2="50.3" y2="39.3" width="0.4" layer="1"/>
 </signal>
 <signal name="PLUNGER_IRQ2">
 <contactref element="RASPBERRY_PI_PICO" pad="GP13"/>
 <contactref element="FRDM1" pad="PTE22"/>
 <contactref element="FRDM1" pad="D9"/>
-<wire x1="42.45" y1="16.595" x2="42.45" y2="14.35" width="0.4" layer="1"/>
-<wire x1="55.15" y1="5.38" x2="55.15" y2="6.75" width="0.4" layer="1"/>
-<wire x1="42.45" y1="14.35" x2="43.45" y2="13.35" width="0.4" layer="1"/>
-<wire x1="43.45" y1="13.35" x2="47.5" y2="13.35" width="0.4" layer="1"/>
-<wire x1="47.5" y1="13.35" x2="52.85" y2="8" width="0.4" layer="1"/>
-<wire x1="52.85" y1="8" x2="53.9" y2="8" width="0.4" layer="1"/>
-<wire x1="53.9" y1="8" x2="55.15" y2="6.75" width="0.4" layer="1"/>
-<wire x1="38.64" y1="51.1" x2="38.7" y2="51.1" width="0.4" layer="1"/>
-<wire x1="38.7" y1="51.1" x2="39.95" y2="49.85" width="0.4" layer="1"/>
-<wire x1="39.95" y1="49.85" x2="40" y2="41.8" width="0.4" layer="1"/>
-<via x="39.4" y="25.55" extent="1-16" drill="0.45"/>
-<via x="42.5" y="18.95" extent="1-16" drill="0.45"/>
-<wire x1="42.5" y1="18.95" x2="42.5" y2="16.645" width="0.4" layer="1"/>
-<wire x1="42.5" y1="16.645" x2="42.45" y2="16.595" width="0.4" layer="1"/>
-<wire x1="38.65" y1="40.45" x2="38.65" y2="32.5" width="0.4" layer="1"/>
-<wire x1="39.4" y1="25.55" x2="39.4" y2="31.75" width="0.4" layer="1"/>
-<wire x1="39.4" y1="31.75" x2="38.65" y2="32.5" width="0.4" layer="1"/>
-<wire x1="39.4" y1="25.55" x2="39.4" y2="25.25" width="0.4" layer="16"/>
-<wire x1="42.5" y1="18.95" x2="42.5" y2="22.15" width="0.4" layer="16"/>
-<wire x1="42.5" y1="22.15" x2="39.4" y2="25.25" width="0.4" layer="16"/>
-<wire x1="38.65" y1="40.45" x2="40" y2="41.8" width="0.4" layer="1"/>
+<wire x1="42.95" y1="17.23" x2="42.95" y2="15.1" width="0.4" layer="1"/>
+<wire x1="42.95" y1="15.1" x2="47.5" y2="10.55" width="0.4" layer="1"/>
+<wire x1="47.5" y1="10.55" x2="50" y2="10.55" width="0.4" layer="1"/>
+<wire x1="55.15" y1="5.38" x2="55.15" y2="5.4" width="0.4" layer="1"/>
+<wire x1="55.15" y1="5.4" x2="50" y2="10.55" width="0.4" layer="1"/>
+<wire x1="39.89" y1="49.85" x2="39.9358" y2="49.85" width="0.4" layer="1"/>
+<wire x1="38.64" y1="51.1" x2="39.89" y2="49.85" width="0.4" layer="1"/>
+<via x="42.975" y="28.575" extent="1-16" drill="0.45"/>
+<via x="42.95" y="21" extent="1-16" drill="0.45"/>
+<wire x1="42.975" y1="28.575" x2="42.95" y2="28.55" width="0.4" layer="16"/>
+<wire x1="42.95" y1="28.55" x2="42.95" y2="21" width="0.4" layer="16"/>
+<wire x1="42.9282" y1="20.9782" x2="42.9282" y2="17.2518" width="0.4" layer="1"/>
+<wire x1="42.95" y1="17.23" x2="42.9282" y2="17.2518" width="0.4" layer="1"/>
+<wire x1="42.9282" y1="20.9782" x2="42.95" y2="21" width="0.4" layer="1"/>
+<wire x1="45.6" y1="31.2" x2="42.975" y2="28.575" width="0.4" layer="1"/>
+<wire x1="52.25" y1="31.2" x2="53.45" y2="32.4" width="0.4" layer="1"/>
+<wire x1="53.45" y1="37.1358" x2="53.45" y2="32.4" width="0.4" layer="1"/>
+<wire x1="45.6" y1="31.2" x2="52.25" y2="31.2" width="0.4" layer="1"/>
+<wire x1="39.9358" y1="43.3642" x2="43.25" y2="40.05" width="0.4" layer="1"/>
+<wire x1="50.5358" y1="40.05" x2="53.45" y2="37.1358" width="0.4" layer="1"/>
+<wire x1="39.9358" y1="49.85" x2="39.9358" y2="43.3642" width="0.4" layer="1"/>
+<wire x1="43.25" y1="40.05" x2="50.5358" y2="40.05" width="0.4" layer="1"/>
 </signal>
 <signal name="PLUNGER_ADC">
 <contactref element="RASPBERRY_PI_PICO" pad="GP28_A2"/>
 <contactref element="FRDM1" pad="A0"/>
 <contactref element="IC5" pad="4"/>
-<wire x1="67.25" y1="10.15" x2="66.2" y2="10.15" width="0.3" layer="1"/>
-<wire x1="50.07" y1="2.84" x2="49.66" y2="2.84" width="0.4" layer="1"/>
-<wire x1="49.66" y1="2.84" x2="48.5" y2="4" width="0.4" layer="1"/>
-<wire x1="48.5" y1="4" x2="48.5" y2="9" width="0.4" layer="1"/>
-<via x="31.15" y="13.95" extent="1-16" drill="0.45"/>
-<via x="27.8" y="31.05" extent="1-16" drill="0.45"/>
-<wire x1="27.8" y1="31.05" x2="18.7" y2="31.05" width="0.4" layer="1"/>
-<wire x1="18.7" y1="31.05" x2="17.05" y2="32.7" width="0.4" layer="1"/>
-<wire x1="17.05" y1="35.645" x2="17.05" y2="32.7" width="0.4" layer="1"/>
-<wire x1="48.5" y1="9" x2="46.2" y2="11.3" width="0.4" layer="1"/>
-<wire x1="46.2" y1="11.3" x2="33.8" y2="11.3" width="0.4" layer="1"/>
-<wire x1="33.8" y1="11.3" x2="31.15" y2="13.95" width="0.4" layer="1"/>
-<wire x1="31.15" y1="13.95" x2="28.75" y2="16.35" width="0.4" layer="16"/>
-<wire x1="28.75" y1="16.35" x2="28.75" y2="30.1" width="0.4" layer="16"/>
-<wire x1="28.75" y1="30.1" x2="27.8" y2="31.05" width="0.4" layer="16"/>
-<wire x1="50.07" y1="2.84" x2="50.14" y2="2.84" width="0.4" layer="1"/>
-<wire x1="50.14" y1="2.84" x2="51.4" y2="4.1" width="0.3" layer="1"/>
-<wire x1="51.4" y1="4.1" x2="64" y2="4.1" width="0.3" layer="1"/>
-<wire x1="64" y1="4.1" x2="65.2" y2="5.3" width="0.3" layer="1"/>
-<wire x1="65.2" y1="5.3" x2="65.2" y2="9.15" width="0.3" layer="1"/>
-<wire x1="65.2" y1="9.15" x2="66.2" y2="10.15" width="0.3" layer="1"/>
+<wire x1="50.07" y1="2.84" x2="45.36" y2="7.55" width="0.4" layer="1"/>
+<wire x1="45.36" y1="7.55" x2="30.925" y2="7.55" width="0.4" layer="1"/>
+<via x="30.925" y="7.55" extent="1-16" drill="0.45"/>
+<wire x1="17.55" y1="35.01" x2="17.55" y2="35" width="0.4" layer="1"/>
+<wire x1="22.41875" y1="30.1" x2="22.41875" y2="30.13125" width="0.4" layer="1"/>
+<wire x1="22.41875" y1="30.13125" x2="17.55" y2="35" width="0.4" layer="1"/>
+<via x="22.41875" y="30.1" extent="1-16" drill="0.45"/>
+<wire x1="32.26875" y1="20.25" x2="22.41875" y2="30.1" width="0.4" layer="16"/>
+<wire x1="55.6039875" y1="17.8539875" x2="51.527" y2="13.777" width="0.4" layer="16"/>
+<wire x1="37.152" y1="13.777" x2="30.925" y2="7.55" width="0.4" layer="16"/>
+<wire x1="51.527" y1="13.777" x2="37.152" y2="13.777" width="0.4" layer="16"/>
+<wire x1="30.925" y1="7.55" x2="26.15" y2="7.55" width="0.3" layer="16"/>
+<wire x1="24.75" y1="6.15" x2="14.55" y2="6.15" width="0.3" layer="16"/>
+<wire x1="14.55" y1="6.15" x2="14.25" y2="5.85" width="0.3" layer="16"/>
+<via x="14.25" y="5.85" extent="1-16" drill="0.45"/>
+<wire x1="14.25" y1="5.85" x2="13.85" y2="6.25" width="0.3" layer="1"/>
+<wire x1="13.85" y1="6.25" x2="12.9" y2="6.25" width="0.3" layer="1"/>
+<wire x1="26.15" y1="7.55" x2="24.75" y2="6.15" width="0.3" layer="16"/>
+<wire x1="55.6039875" y1="19.230578125" x2="55.6039875" y2="17.8539875" width="0.4" layer="16"/>
+<wire x1="55.6039875" y1="19.230578125" x2="54.584565625" y2="20.25" width="0.4" layer="16"/>
+<wire x1="54.584565625" y1="20.25" x2="32.26875" y2="20.25" width="0.4" layer="16"/>
 </signal>
 <signal name="PSU2_STATUS_SET">
 <contactref element="FRDM1" pad="D14"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP21"/>
-<wire x1="20.86" y1="51.1" x2="21.25" y2="51.1" width="0.4" layer="1"/>
-<wire x1="21.25" y1="51.1" x2="22.1" y2="50.25" width="0.4" layer="1"/>
-<wire x1="22.1" y1="50.25" x2="22.1" y2="46.8" width="0.4" layer="1"/>
-<wire x1="22.1" y1="46.8" x2="30.15" y2="38.75" width="0.4" layer="1"/>
-<wire x1="30.15" y1="38.75" x2="33.45" y2="38.75" width="0.4" layer="1"/>
-<wire x1="33.45" y1="38.75" x2="34.83" y2="37.37" width="0.4" layer="1"/>
-<wire x1="34.83" y1="35.645" x2="34.83" y2="37.37" width="0.4" layer="1"/>
+<wire x1="20.86" y1="51.1" x2="22.15" y2="49.81" width="0.4" layer="1"/>
+<wire x1="22.15" y1="49.81" x2="22.15" y2="47.6" width="0.4" layer="1"/>
+<wire x1="22.15" y1="47.6" x2="25.5" y2="44.25" width="0.4" layer="1"/>
+<wire x1="25.5" y1="44.25" x2="29.05" y2="44.25" width="0.4" layer="1"/>
+<wire x1="29.05" y1="44.25" x2="35.33" y2="37.97" width="0.4" layer="1"/>
+<wire x1="35.33" y1="37.97" x2="35.33" y2="35.01" width="0.4" layer="1"/>
 </signal>
 <signal name="PSU2_STATUS_SENSE">
 <contactref element="FRDM1" pad="D11"/>
+<wire x1="33.56" y1="51.1" x2="34.3" y2="51.1" width="0.4" layer="1"/>
+<wire x1="34.3" y1="51.1" x2="34.85" y2="50.55" width="0.4" layer="1"/>
+<wire x1="34.85" y1="50.55" x2="34.85" y2="43.75" width="0.4" layer="1"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP20"/>
-<wire x1="33.56" y1="51.1" x2="33.8" y2="51.1" width="0.4" layer="1"/>
-<wire x1="33.8" y1="51.1" x2="34.8" y2="50.1" width="0.4" layer="1"/>
-<wire x1="34.8" y1="50.1" x2="34.8" y2="46.25" width="0.4" layer="1"/>
-<wire x1="34.8" y1="46.25" x2="34.95" y2="46.1" width="0.4" layer="1"/>
-<wire x1="34.95" y1="46.1" x2="34.95" y2="39.25" width="0.4" layer="1"/>
-<wire x1="37.37" y1="35.645" x2="37.37" y2="36.83" width="0.4" layer="1"/>
-<wire x1="37.37" y1="36.83" x2="34.95" y2="39.25" width="0.4" layer="1"/>
+<wire x1="37.87" y1="40.73" x2="37.87" y2="35.01" width="0.4" layer="1"/>
+<wire x1="34.85" y1="43.75" x2="37.87" y2="40.73" width="0.4" layer="1"/>
 </signal>
 <signal name="IR_IN">
 <contactref element="FRDM1" pad="D8"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP6"/>
-<wire x1="41.18" y1="51.1" x2="41.8" y2="51.1" width="0.4" layer="1"/>
-<wire x1="41.8" y1="51.1" x2="42.5" y2="50.4" width="0.4" layer="1"/>
-<wire x1="42.5" y1="50.4" x2="42.5" y2="40" width="0.4" layer="1"/>
-<wire x1="27.15" y1="24.2" x2="22.13" y2="19.18" width="0.4" layer="1"/>
-<wire x1="22.13" y1="16.595" x2="22.13" y2="19.18" width="0.4" layer="1"/>
-<wire x1="27.15" y1="24.2" x2="39.25" y2="24.2" width="0.4" layer="1"/>
-<wire x1="41.2" y1="32.65" x2="40.4" y2="31.85" width="0.4" layer="1"/>
-<wire x1="40.4" y1="31.85" x2="40.4" y2="25.35" width="0.4" layer="1"/>
-<wire x1="42.5" y1="40" x2="41.15" y2="38.65" width="0.4" layer="1"/>
-<wire x1="41.15" y1="38.65" x2="41.2" y2="32.65" width="0.4" layer="1"/>
-<wire x1="39.25" y1="24.2" x2="40.4" y2="25.35" width="0.4" layer="1"/>
+<wire x1="27.25" y1="21.85" x2="22.63" y2="17.23" width="0.4" layer="1"/>
+<wire x1="41.18" y1="51.1" x2="42.78" y2="52.7" width="0.4" layer="1"/>
+<wire x1="46.25" y1="52.2" x2="46.25" y2="47.5" width="0.4" layer="1"/>
+<wire x1="46.25" y1="47.5" x2="55.2" y2="38.55" width="0.4" layer="1"/>
+<wire x1="55.2" y1="38.55" x2="55.2" y2="23.65" width="0.4" layer="1"/>
+<wire x1="55.2" y1="23.65" x2="53.4" y2="21.85" width="0.4" layer="1"/>
+<wire x1="42.78" y1="52.7" x2="45.75" y2="52.7" width="0.4" layer="1"/>
+<wire x1="45.75" y1="52.7" x2="46.25" y2="52.2" width="0.4" layer="1"/>
+<wire x1="53.4" y1="21.85" x2="27.25" y2="21.85" width="0.4" layer="1"/>
 </signal>
 <signal name="IR_OUT">
 <contactref element="RASPBERRY_PI_PICO" pad="GP0"/>
 <contactref element="FRDM1" pad="D7"/>
-<wire x1="44.99" y1="51.1" x2="44.05" y2="51.1" width="0.4" layer="1"/>
-<wire x1="44.05" y1="51.1" x2="43.3" y2="50.35" width="0.4" layer="1"/>
-<wire x1="43.3" y1="50.35" x2="43.25" y2="42.35" width="0.4" layer="1"/>
-<wire x1="28.05" y1="23.4" x2="26.75" y2="22.1" width="0.4" layer="1"/>
-<via x="26.75" y="22.1" extent="1-16" drill="0.45"/>
-<wire x1="26.75" y1="22.1" x2="15.4" y2="22.1" width="0.4" layer="16"/>
-<via x="15.4" y="22.1" extent="1-16" drill="0.45"/>
-<wire x1="15.4" y1="22.1" x2="5.9" y2="22.1" width="0.4" layer="1"/>
-<wire x1="5.9" y1="22.1" x2="1.81" y2="18.01" width="0.4" layer="1"/>
-<wire x1="1.81" y1="16.595" x2="1.81" y2="18.01" width="0.4" layer="1"/>
-<wire x1="28.05" y1="23.4" x2="39.4" y2="23.4" width="0.4" layer="1"/>
-<wire x1="41.3" y1="25.3" x2="41.3" y2="30.95" width="0.4" layer="1"/>
-<wire x1="41.3" y1="30.95" x2="43.65" y2="33.3" width="0.4" layer="1"/>
-<wire x1="43.65" y1="41.95" x2="43.25" y2="42.35" width="0.4" layer="1"/>
-<wire x1="43.65" y1="41.95" x2="43.65" y2="33.3" width="0.4" layer="1"/>
-<wire x1="39.4" y1="23.4" x2="41.3" y2="25.3" width="0.4" layer="1"/>
+<wire x1="2.33" y1="17.23" x2="12.95" y2="27.85" width="0.4" layer="1"/>
+<wire x1="2.31" y1="17.23" x2="2.33" y2="17.23" width="0.4" layer="1"/>
+<wire x1="45.15" y1="27.85" x2="12.95" y2="27.85" width="0.4" layer="1"/>
+<wire x1="44.99" y1="51.1" x2="43.8" y2="51.1" width="0.4" layer="1"/>
+<wire x1="43.8" y1="51.1" x2="43.05" y2="50.35" width="0.4" layer="1"/>
+<wire x1="43.05" y1="50.35" x2="43.05" y2="48.05" width="0.4" layer="1"/>
+<wire x1="54.3" y1="32.2" x2="52.5" y2="30.4" width="0.4" layer="1"/>
+<wire x1="47.7" y1="30.4" x2="45.15" y2="27.85" width="0.4" layer="1"/>
+<wire x1="43.05" y1="48.05" x2="47.6" y2="43.5" width="0.4" layer="1"/>
+<wire x1="47.6" y1="43.5" x2="48.15" y2="43.5" width="0.4" layer="1"/>
+<wire x1="48.15" y1="43.5" x2="54.3" y2="37.35" width="0.4" layer="1"/>
+<wire x1="54.3" y1="37.35" x2="54.3" y2="32.2" width="0.4" layer="1"/>
+<wire x1="52.5" y1="30.4" x2="47.7" y2="30.4" width="0.4" layer="1"/>
 </signal>
 <signal name="PWM_XLAT">
 <contactref element="FRDM1" pad="PTC10"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP19"/>
-<wire x1="47.53" y1="48.56" x2="47.53" y2="41.67" width="0.4" layer="1"/>
-<wire x1="47.53" y1="41.67" x2="48" y2="41.2" width="0.4" layer="1"/>
-<wire x1="48" y1="41.2" x2="48" y2="39.65" width="0.4" layer="1"/>
-<wire x1="48" y1="39.65" x2="47.35" y2="39" width="0.4" layer="1"/>
-<via x="47.35" y="39" extent="1-16" drill="0.45"/>
-<via x="40.9" y="40.75" extent="1-16" drill="0.45"/>
-<wire x1="39.91" y1="35.645" x2="39.91" y2="39.76" width="0.4" layer="1"/>
-<wire x1="47.35" y1="39" x2="46.25" y2="39" width="0.4" layer="16"/>
-<wire x1="40.9" y1="40.75" x2="44.5" y2="40.75" width="0.4" layer="16"/>
-<wire x1="44.5" y1="40.75" x2="46.25" y2="39" width="0.4" layer="16"/>
-<wire x1="39.91" y1="39.76" x2="40.9" y2="40.75" width="0.4" layer="1"/>
+<wire x1="47.53" y1="48.56" x2="47.53" y2="47.32" width="0.4" layer="1"/>
+<wire x1="54" y1="40.85" x2="54" y2="40.8" width="0.4" layer="1"/>
+<wire x1="54" y1="40.85" x2="47.53" y2="47.32" width="0.4" layer="1"/>
+<via x="54" y="40.8" extent="1-16" drill="0.45"/>
+<via x="40.4" y="38.6" extent="1-16" drill="0.45"/>
+<wire x1="40.4" y1="38.6" x2="40.41" y2="38.59" width="0.4" layer="1"/>
+<wire x1="40.41" y1="38.59" x2="40.41" y2="35.01" width="0.4" layer="1"/>
+<wire x1="54" y1="40.8" x2="42.6" y2="40.8" width="0.4" layer="16"/>
+<wire x1="42.6" y1="40.8" x2="40.4" y2="38.6" width="0.4" layer="16"/>
 </signal>
 <signal name="PWM_SIN">
 <contactref element="FRDM1" pad="PTC6"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP17"/>
-<wire x1="50.07" y1="48.56" x2="50.07" y2="39.32" width="0.4" layer="1"/>
-<wire x1="50.07" y1="39.32" x2="47.53" y2="36.78" width="0.4" layer="1"/>
-<wire x1="47.53" y1="35.645" x2="47.53" y2="36.78" width="0.4" layer="1"/>
+<wire x1="56.72" y1="41.31" x2="50.07" y2="47.96" width="0.4" layer="1"/>
+<wire x1="50.07" y1="47.96" x2="50.07" y2="48.56" width="0.4" layer="1"/>
+<wire x1="56.72" y1="34.49" x2="56.72" y2="41.31" width="0.4" layer="1"/>
+<via x="56.72" y="34.49" extent="1-16" drill="0.45"/>
+<wire x1="56.25" y1="33.5" x2="49.55" y2="33.5" width="0.4" layer="16"/>
+<wire x1="56.72" y1="34.49" x2="56.72" y2="33.97" width="0.4" layer="16"/>
+<wire x1="56.72" y1="33.97" x2="56.25" y2="33.5" width="0.4" layer="16"/>
+<via x="49.55" y="33.5" extent="1-16" drill="0.45"/>
+<wire x1="49.55" y1="33.5" x2="48.0397625" y2="35.01" width="0.4" layer="1"/>
+<wire x1="48.03" y1="35.01" x2="48.0397625" y2="35.01" width="0.4" layer="1"/>
 </signal>
 <signal name="PWM_BLANK">
 <contactref element="FRDM1" pad="PTC7"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP18"/>
-<wire x1="62.77" y1="48.56" x2="62.77" y2="47.27" width="0.4" layer="1"/>
-<wire x1="62.77" y1="47.27" x2="61.55" y2="46.05" width="0.4" layer="1"/>
-<wire x1="61.55" y1="46.05" x2="61.55" y2="37" width="0.4" layer="1"/>
-<wire x1="61.55" y1="37" x2="60.9" y2="36.35" width="0.4" layer="1"/>
-<via x="60.9" y="36.35" extent="1-16" drill="0.45"/>
-<wire x1="60.9" y1="36.35" x2="44.2" y2="36.35" width="0.4" layer="16"/>
-<via x="42.6" y="37.95" extent="1-16" drill="0.45"/>
-<wire x1="42.45" y1="35.645" x2="42.45" y2="37.8" width="0.4" layer="1"/>
-<wire x1="42.45" y1="37.8" x2="42.6" y2="37.95" width="0.4" layer="1"/>
-<wire x1="44.2" y1="36.35" x2="42.6" y2="37.95" width="0.4" layer="16"/>
+<wire x1="44.3" y1="33.6" x2="45.9" y2="32" width="0.4" layer="16"/>
+<wire x1="45.9" y1="32" x2="63.75" y2="32" width="0.4" layer="16"/>
+<via x="44.3" y="33.6" extent="1-16" drill="0.45"/>
+<wire x1="42.95" y1="35.01" x2="44.3" y2="33.66" width="0.4" layer="1"/>
+<wire x1="44.3" y1="33.66" x2="44.3" y2="33.6" width="0.4" layer="1"/>
+<wire x1="62.77" y1="48.56" x2="64.51" y2="50.3" width="0.4" layer="16"/>
+<wire x1="76.9" y1="48.5" x2="76.9" y2="39.7" width="0.4" layer="16"/>
+<wire x1="76.9" y1="39.7" x2="75.35" y2="38.15" width="0.4" layer="16"/>
+<wire x1="75.35" y1="38.15" x2="71.8" y2="38.15" width="0.4" layer="16"/>
+<wire x1="64.51" y1="50.3" x2="75.1" y2="50.3" width="0.4" layer="16"/>
+<wire x1="75.1" y1="50.3" x2="76.9" y2="48.5" width="0.4" layer="16"/>
+<via x="71.8" y="38.15" extent="1-16" drill="0.45"/>
+<wire x1="71.8" y1="38.15" x2="71.75" y2="38.1" width="0.4" layer="1"/>
+<wire x1="71.75" y1="38.1" x2="69.85" y2="38.1" width="0.4" layer="1"/>
+<via x="69.85" y="38.1" extent="1-16" drill="0.45"/>
+<wire x1="63.75" y1="32" x2="69.85" y2="38.1" width="0.4" layer="16"/>
 </signal>
 <signal name="PWM_SCLK">
 <contactref element="FRDM1" pad="PTC5"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP15"/>
-<wire x1="50.07" y1="16.595" x2="50.07" y2="18.42" width="0.4" layer="1"/>
-<wire x1="50.07" y1="18.42" x2="50.6" y2="18.95" width="0.4" layer="1"/>
-<wire x1="51.4" y1="30.45" x2="52.35" y2="29.5" width="0.4" layer="1"/>
-<wire x1="52.35" y1="29.5" x2="52.35" y2="20.7" width="0.4" layer="1"/>
-<wire x1="52.35" y1="20.7" x2="51.9" y2="20.2" width="0.4" layer="1"/>
-<wire x1="51.9" y1="20.2" x2="50.6" y2="18.95" width="0.4" layer="1"/>
-<wire x1="52.61" y1="48.56" x2="52.61" y2="47.21" width="0.4" layer="1"/>
-<wire x1="51.4" y1="30.45" x2="51.4" y2="36.4" width="0.4" layer="1"/>
-<wire x1="51.4" y1="36.4" x2="52" y2="37" width="0.4" layer="1"/>
-<wire x1="52" y1="37" x2="52" y2="46.6" width="0.4" layer="1"/>
-<wire x1="52" y1="46.6" x2="52.61" y2="47.21" width="0.4" layer="1"/>
+<wire x1="58.31" y1="42.01" x2="52.61" y2="47.71" width="0.4" layer="1"/>
+<wire x1="52.61" y1="48.56" x2="52.61" y2="47.71" width="0.4" layer="1"/>
+<wire x1="50.57" y1="17.23" x2="58.31" y2="24.97" width="0.4" layer="1"/>
+<wire x1="58.31" y1="24.97" x2="58.31" y2="42.01" width="0.4" layer="1"/>
 </signal>
 <signal name="PWM_GSCLK">
 <contactref element="FRDM1" pad="D0"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP16"/>
-<wire x1="62.77" y1="51.1" x2="62.7" y2="51.1" width="0.4" layer="1"/>
-<wire x1="62.7" y1="51.1" x2="61.5" y2="49.9" width="0.4" layer="1"/>
-<wire x1="61.5" y1="49.9" x2="61.5" y2="47.05" width="0.4" layer="1"/>
-<wire x1="61.5" y1="47.05" x2="60.9" y2="46.45" width="0.4" layer="1"/>
-<wire x1="60.9" y1="46.45" x2="60.9" y2="38.75" width="0.4" layer="1"/>
-<via x="59.3" y="37.25" extent="1-16" drill="0.45"/>
-<wire x1="59.3" y1="37.25" x2="51.15" y2="37.2" width="0.4" layer="16"/>
-<via x="51.15" y="37.2" extent="1-16" drill="0.45"/>
-<wire x1="50.07" y1="35.645" x2="50.07" y2="36.87" width="0.4" layer="1"/>
-<wire x1="51.15" y1="37.2" x2="50.8" y2="37.2" width="0.4" layer="1"/>
-<wire x1="50.8" y1="37.2" x2="50.07" y2="36.87" width="0.4" layer="1"/>
-<wire x1="59.3" y1="37.25" x2="59.4" y2="37.25" width="0.4" layer="1"/>
-<wire x1="59.4" y1="37.25" x2="60.9" y2="38.75" width="0.4" layer="1"/>
+<wire x1="63.3" y1="32.75" x2="67.95" y2="37.4" width="0.4" layer="16"/>
+<wire x1="63.3" y1="32.75" x2="51.45" y2="32.75" width="0.4" layer="16"/>
+<via x="51.45" y="32.75" extent="1-16" drill="0.45"/>
+<wire x1="50.57" y1="35.01" x2="50.57" y2="33.63" width="0.4" layer="1"/>
+<wire x1="50.57" y1="33.63" x2="51.45" y2="32.75" width="0.4" layer="1"/>
+<wire x1="62.77" y1="51.1" x2="75.45" y2="51.1" width="0.4" layer="16"/>
+<wire x1="77.7" y1="48.85" x2="77.7" y2="39.35" width="0.4" layer="16"/>
+<wire x1="75.723" y1="37.373" x2="77.7" y2="39.35" width="0.4" layer="16"/>
+<wire x1="75.45" y1="51.1" x2="77.7" y2="48.85" width="0.4" layer="16"/>
+<via x="67.95" y="37.4" extent="1-16" drill="0.45"/>
+<wire x1="71.85" y1="37.4" x2="67.95" y2="37.4" width="0.4" layer="1"/>
+<via x="71.85" y="37.4" extent="1-16" drill="0.45"/>
+<wire x1="71.85" y1="37.4" x2="71.877" y2="37.373" width="0.4" layer="16"/>
+<wire x1="71.877" y1="37.373" x2="75.723" y2="37.373" width="0.4" layer="16"/>
 </signal>
 <signal name="CHIME_SOUT">
 <contactref element="FRDM1" pad="D5"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP3"/>
-<wire x1="50.07" y1="51.1" x2="49.9" y2="51.1" width="0.4" layer="1"/>
-<wire x1="49.9" y1="51.1" x2="48.8" y2="50" width="0.4" layer="1"/>
-<wire x1="48.8" y1="50" x2="48.8" y2="39.15" width="0.4" layer="1"/>
-<wire x1="11.9" y1="35.4" x2="11.9" y2="18.8" width="0.4" layer="16"/>
-<via x="11.9" y="18.8" extent="1-16" drill="0.45"/>
-<wire x1="11.97" y1="16.595" x2="11.92" y2="17.68" width="0.4" layer="1"/>
-<wire x1="11.92" y1="17.68" x2="11.9" y2="18.8" width="0.4" layer="1"/>
-<wire x1="48.8" y1="39.15" x2="48" y2="38.35" width="0.4" layer="1"/>
-<via x="48" y="38.35" extent="1-16" drill="0.45"/>
-<wire x1="48" y1="38.35" x2="44.85" y2="38.35" width="0.4" layer="16"/>
-<wire x1="44.85" y1="38.35" x2="43.55" y2="39.65" width="0.4" layer="16"/>
-<wire x1="39.8" y1="39.65" x2="43.55" y2="39.65" width="0.4" layer="16"/>
-<wire x1="18" y1="41.5" x2="37.95" y2="41.5" width="0.4" layer="16"/>
-<wire x1="39.8" y1="39.65" x2="37.95" y2="41.5" width="0.4" layer="16"/>
-<wire x1="11.9" y1="35.4" x2="18" y2="41.5" width="0.4" layer="16"/>
+<wire x1="0.593" y1="38.593" x2="14.7" y2="52.7" width="0.4" layer="16"/>
+<wire x1="0.593" y1="38.593" x2="0.593" y2="34.057" width="0.4" layer="16"/>
+<wire x1="12.45" y1="18.9" x2="12.45" y2="30.45" width="0.4" layer="16"/>
+<wire x1="12.45" y1="30.45" x2="9.725" y2="33.175" width="0.4" layer="16"/>
+<wire x1="9.725" y1="33.175" x2="1.475" y2="33.175" width="0.4" layer="16"/>
+<via x="12.45" y="18.9" extent="1-16" drill="0.45"/>
+<wire x1="1.475" y1="33.175" x2="0.593" y2="34.057" width="0.4" layer="16"/>
+<wire x1="12.45" y1="18.9" x2="12.47" y2="18.88" width="0.4" layer="1"/>
+<wire x1="12.47" y1="18.88" x2="12.47" y2="17.23" width="0.4" layer="1"/>
+<wire x1="48.47" y1="52.7" x2="50.07" y2="51.1" width="0.4" layer="16"/>
+<wire x1="14.7" y1="52.7" x2="48.47" y2="52.7" width="0.4" layer="16"/>
 </signal>
 <signal name="CHIME_SCLK">
 <contactref element="FRDM1" pad="D4"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP1"/>
 <wire x1="52.61" y1="51.1" x2="52.5" y2="51.1" width="0.4" layer="1"/>
 <wire x1="52.5" y1="51.1" x2="51.35" y2="49.95" width="0.4" layer="1"/>
-<via x="50.35" y="38.25" extent="1-16" drill="0.45"/>
-<wire x1="50.35" y1="38.25" x2="50.3" y2="38.25" width="0.4" layer="16"/>
-<wire x1="50.3" y1="38.25" x2="49.5" y2="37.45" width="0.4" layer="16"/>
-<wire x1="49.5" y1="37.45" x2="44.6" y2="37.45" width="0.4" layer="16"/>
-<wire x1="44.6" y1="37.45" x2="43.15" y2="38.9" width="0.4" layer="16"/>
-<wire x1="37.25" y1="40.8" x2="20.45" y2="40.8" width="0.4" layer="16"/>
-<via x="13.4" y="21.25" extent="1-16" drill="0.45"/>
-<wire x1="12.35" y1="20.2" x2="6.55" y2="20.2" width="0.4" layer="1"/>
-<wire x1="6.55" y1="20.2" x2="4.35" y2="18" width="0.4" layer="1"/>
-<wire x1="4.35" y1="16.595" x2="4.35" y2="18" width="0.4" layer="1"/>
-<wire x1="51.35" y1="49.95" x2="51.35" y2="39.25" width="0.4" layer="1"/>
-<wire x1="51.35" y1="39.25" x2="50.35" y2="38.25" width="0.4" layer="1"/>
-<wire x1="43.15" y1="38.9" x2="39.15" y2="38.9" width="0.4" layer="16"/>
-<wire x1="39.15" y1="38.9" x2="37.25" y2="40.8" width="0.4" layer="16"/>
-<wire x1="12.35" y1="20.2" x2="13.4" y2="21.25" width="0.4" layer="1"/>
-<wire x1="13.4" y1="21.25" x2="13.4" y2="33.75" width="0.4" layer="16"/>
-<wire x1="20.45" y1="40.8" x2="13.4" y2="33.75" width="0.4" layer="16"/>
+<via x="57.15" y="31.2" extent="1-16" drill="0.45"/>
+<wire x1="57.15" y1="31.2" x2="20.2" y2="31.2" width="0.4" layer="16"/>
+<wire x1="20.2" y1="31.2" x2="16" y2="27" width="0.4" layer="16"/>
+<via x="16" y="27" extent="1-16" drill="0.45"/>
+<wire x1="16" y1="27" x2="14.5" y2="27" width="0.4" layer="1"/>
+<wire x1="14.5" y1="27" x2="4.85" y2="17.35" width="0.4" layer="1"/>
+<wire x1="4.85" y1="17.23" x2="4.85" y2="17.35" width="0.4" layer="1"/>
+<wire x1="57.5" y1="31.55" x2="57.15" y2="31.2" width="0.4" layer="1"/>
+<wire x1="51.35" y1="47.68755" x2="51.88755" y2="47.15" width="0.4" layer="1"/>
+<wire x1="51.88755" y1="47.15" x2="51.95" y2="47.15" width="0.4" layer="1"/>
+<wire x1="51.95" y1="47.15" x2="57.5" y2="41.6" width="0.4" layer="1"/>
+<wire x1="51.35" y1="49.95" x2="51.35" y2="47.68755" width="0.4" layer="1"/>
+<wire x1="57.5" y1="41.6" x2="57.5" y2="31.55" width="0.4" layer="1"/>
 </signal>
 <signal name="CHIME_LATCH">
 <contactref element="FRDM1" pad="D3"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP2"/>
-<wire x1="55.15" y1="51.1" x2="53.9" y2="49.85" width="0.4" layer="1"/>
-<wire x1="53.9" y1="49.85" x2="53.9" y2="47.15" width="0.4" layer="1"/>
-<wire x1="53.9" y1="47.15" x2="52.6" y2="45.85" width="0.4" layer="1"/>
-<wire x1="52.05" y1="31.45" x2="52.35" y2="31.15" width="0.4" layer="1"/>
-<via x="52.35" y="31.15" extent="1-16" drill="0.45"/>
-<wire x1="52.35" y1="31.15" x2="38.1" y2="31.15" width="0.4" layer="16"/>
-<wire x1="38.1" y1="31.15" x2="35.95" y2="29" width="0.4" layer="16"/>
-<wire x1="35.95" y1="29" x2="35.95" y2="27.25" width="0.4" layer="16"/>
-<wire x1="9.43" y1="16.595" x2="9.43" y2="18.28" width="0.4" layer="1"/>
-<wire x1="9.43" y1="18.28" x2="10.65" y2="19.5" width="0.4" layer="1"/>
-<wire x1="10.65" y1="19.5" x2="13.05" y2="19.5" width="0.4" layer="1"/>
-<wire x1="13.05" y1="19.5" x2="14.6" y2="21.05" width="0.4" layer="1"/>
-<wire x1="14.6" y1="21.05" x2="15.8" y2="21.05" width="0.4" layer="1"/>
-<wire x1="15.8" y1="21.05" x2="21.55" y2="26.8" width="0.4" layer="1"/>
-<wire x1="35.5" y1="26.8" x2="35.95" y2="27.25" width="0.4" layer="1"/>
-<via x="35.95" y="27.25" extent="1-16" drill="0.45"/>
-<wire x1="52.05" y1="31.45" x2="52" y2="35.9" width="0.4" layer="1"/>
-<wire x1="52" y1="35.9" x2="52.55" y2="36.45" width="0.4" layer="1"/>
-<wire x1="52.55" y1="36.45" x2="52.6" y2="45.85" width="0.4" layer="1"/>
-<wire x1="35.5" y1="26.8" x2="21.55" y2="26.8" width="0.4" layer="1"/>
+<wire x1="53.9" y1="49.85" x2="55.15" y2="51.1" width="0.4" layer="1"/>
+<via x="59.15" y="30.95" extent="1-16" drill="0.45"/>
+<wire x1="59.15" y1="30.95" x2="59.1" y2="30.95" width="0.4" layer="16"/>
+<wire x1="59.1" y1="30.95" x2="58.55" y2="30.4" width="0.4" layer="16"/>
+<wire x1="58.55" y1="30.4" x2="43.7" y2="30.4" width="0.4" layer="16"/>
+<wire x1="43.7" y1="30.4" x2="40.35" y2="27.05" width="0.4" layer="16"/>
+<wire x1="40.35" y1="27" x2="40.35" y2="27.05" width="0.4" layer="16"/>
+<wire x1="9.93" y1="17.23" x2="9.93" y2="17.63" width="0.4" layer="1"/>
+<wire x1="9.93" y1="17.63" x2="19.3" y2="27" width="0.4" layer="1"/>
+<wire x1="19.3" y1="27" x2="40.35" y2="27" width="0.4" layer="1"/>
+<via x="40.35" y="27" extent="1-16" drill="0.45"/>
+<wire x1="59.15" y1="30.95" x2="59.15" y2="42.4" width="0.4" layer="1"/>
+<wire x1="59.15" y1="42.4" x2="54.45" y2="47.1" width="0.4" layer="1"/>
+<wire x1="54.45" y1="47.1" x2="54.25" y2="47.1" width="0.4" layer="1"/>
+<wire x1="54.25" y1="47.1" x2="53.9" y2="47.45" width="0.4" layer="1"/>
+<wire x1="53.9" y1="47.45" x2="53.9" y2="49.85" width="0.4" layer="1"/>
 </signal>
 <signal name="CHIME_ENA">
 <contactref element="FRDM1" pad="D2"/>
 <contactref element="IC6" pad="7"/>
-<wire x1="56.4" y1="47.1" x2="56.4" y2="49.81" width="0.4" layer="1"/>
-<wire x1="56.4" y1="49.81" x2="57.69" y2="51.1" width="0.4" layer="1"/>
-<wire x1="56.225" y1="35.038" x2="56.225" y2="46.925" width="0.4" layer="1"/>
-<wire x1="56.225" y1="46.925" x2="56.4" y2="47.1" width="0.4" layer="1"/>
+<wire x1="56.45" y1="47.5" x2="56.45" y2="49.86" width="0.4" layer="1"/>
+<wire x1="56.45" y1="49.86" x2="57.69" y2="51.1" width="0.4" layer="1"/>
+<wire x1="60.713" y1="40.06270625" x2="60.713" y2="43.237" width="0.4" layer="1"/>
+<wire x1="68.10070625" y1="32.675" x2="60.713" y2="40.06270625" width="0.4" layer="1"/>
+<wire x1="68.10070625" y1="32.675" x2="70.112" y2="32.675" width="0.4" layer="1"/>
+<wire x1="56.45" y1="47.5" x2="60.713" y2="43.237" width="0.4" layer="1"/>
 </signal>
 <signal name="N$8">
 <contactref element="R3" pad="2"/>
@@ -4609,191 +4766,197 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 <signal name="LED_R">
 <contactref element="R3" pad="1"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP27_A1"/>
-<wire x1="22.13" y1="35.645" x2="22.13" y2="37.42" width="0.4064" layer="1"/>
-<wire x1="22.13" y1="37.42" x2="20.475" y2="39.075" width="0.4064" layer="1"/>
+<wire x1="22.63" y1="35.01" x2="22.63" y2="37.87" width="0.4064" layer="1"/>
+<wire x1="22.63" y1="37.87" x2="21.45" y2="39.05" width="0.4064" layer="1"/>
 <wire x1="9.172" y1="43.25" x2="9.95" y2="43.25" width="0.4" layer="1"/>
-<wire x1="9.95" y1="43.25" x2="14" y2="39.2" width="0.4" layer="1"/>
-<wire x1="14" y1="39.2" x2="20.35" y2="39.2" width="0.4" layer="1"/>
-<wire x1="20.35" y1="39.2" x2="20.475" y2="39.075" width="0.4" layer="1"/>
+<wire x1="9.95" y1="43.25" x2="14.15" y2="39.05" width="0.4" layer="1"/>
+<wire x1="21.45" y1="39.05" x2="14.15" y2="39.05" width="0.4" layer="1"/>
 </signal>
 <signal name="LED_B">
 <contactref element="R1" pad="1"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP22"/>
+<wire x1="30.25" y1="35.01" x2="30.25" y2="37.2" width="0.4064" layer="1"/>
+<wire x1="30.25" y1="37.2" x2="28.4" y2="39.05" width="0.4064" layer="1"/>
 <wire x1="9.172" y1="48.25" x2="10.1" y2="48.25" width="0.4" layer="1"/>
-<wire x1="10.1" y1="48.25" x2="14.9" y2="43.45" width="0.4" layer="1"/>
-<wire x1="14.9" y1="43.45" x2="23.5" y2="43.45" width="0.4" layer="1"/>
-<wire x1="23.5" y1="43.45" x2="29.75" y2="37.2" width="0.4" layer="1"/>
-<wire x1="29.75" y1="35.645" x2="29.75" y2="37.2" width="0.4" layer="1"/>
+<wire x1="10.1" y1="48.25" x2="15.9" y2="42.45" width="0.4" layer="1"/>
+<wire x1="15.9" y1="42.45" x2="25" y2="42.45" width="0.4" layer="1"/>
+<wire x1="25" y1="42.45" x2="28.4" y2="39.05" width="0.4" layer="1"/>
 </signal>
 <signal name="LED_G">
 <contactref element="R2" pad="1"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP26_A0"/>
-<wire x1="24.67" y1="35.645" x2="24.67" y2="37.18" width="0.4064" layer="1"/>
-<wire x1="24.67" y1="37.18" x2="22.325" y2="39.525" width="0.4064" layer="1"/>
+<wire x1="25.17" y1="35.01" x2="25.17" y2="37.98" width="0.4064" layer="1"/>
 <wire x1="9.172" y1="45.75" x2="9.85" y2="45.75" width="0.4" layer="1"/>
 <wire x1="9.85" y1="45.75" x2="11.25" y2="44.35" width="0.4" layer="1"/>
-<wire x1="11.25" y1="44.35" x2="11.25" y2="43.1" width="0.4" layer="1"/>
-<wire x1="11.25" y1="43.1" x2="14.45" y2="39.9" width="0.4" layer="1"/>
-<wire x1="14.45" y1="39.9" x2="21.95" y2="39.9" width="0.4" layer="1"/>
-<wire x1="21.95" y1="39.9" x2="22.325" y2="39.525" width="0.4" layer="1"/>
+<wire x1="11.25" y1="44.35" x2="11.25" y2="43.3" width="0.4" layer="1"/>
+<wire x1="11.25" y1="43.3" x2="14.65" y2="39.9" width="0.4" layer="1"/>
+<wire x1="14.65" y1="39.9" x2="23.25" y2="39.9" width="0.4" layer="1"/>
+<wire x1="23.25" y1="39.9" x2="25.17" y2="37.98" width="0.4" layer="1"/>
 </signal>
 <signal name="PICO_RUN">
 <contactref element="SW1" pad="A"/>
 <contactref element="SW1" pad="B"/>
 <contactref element="RASPBERRY_PI_PICO" pad="RUN"/>
 <wire x1="22.25" y1="40.775" x2="16.25" y2="40.775" width="0.3" layer="1"/>
-<wire x1="27.21" y1="35.645" x2="27.21" y2="36.84" width="0.4" layer="1"/>
-<wire x1="27.21" y1="36.84" x2="23.275" y2="40.775" width="0.4" layer="1"/>
-<wire x1="22.25" y1="40.775" x2="23.275" y2="40.775" width="0.4" layer="1"/>
+<wire x1="27.71" y1="35.01" x2="27.71" y2="37.94" width="0.4" layer="1"/>
+<wire x1="27.71" y1="37.94" x2="24.875" y2="40.775" width="0.4" layer="1"/>
+<wire x1="22.25" y1="40.775" x2="24.875" y2="40.775" width="0.4" layer="1"/>
 </signal>
 <signal name="ADC_INTR">
 <contactref element="IC5" pad="2"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP7"/>
-<via x="30.35" y="9.05" extent="1-16" drill="0.35"/>
-<wire x1="30.35" y1="9.05" x2="30.3" y2="9.05" width="0.3" layer="16"/>
-<wire x1="30.3" y1="9.05" x2="28.3" y2="11.05" width="0.3" layer="16"/>
-<via x="28.3" y="11.05" extent="1-16" drill="0.35"/>
-<wire x1="24.67" y1="16.595" x2="24.67" y2="14.68" width="0.3" layer="1"/>
-<wire x1="24.67" y1="14.68" x2="28.3" y2="11.05" width="0.3" layer="1"/>
-<wire x1="30.35" y1="9.05" x2="46.2" y2="9.05" width="0.3" layer="1"/>
-<via x="46.2" y="9.05" extent="1-16" drill="0.35"/>
-<via x="56.6" y="10.2" extent="1-16" drill="0.35"/>
-<wire x1="46.2" y1="9.05" x2="50.2" y2="9.05" width="0.3" layer="16"/>
-<wire x1="50.2" y1="9.05" x2="51.35" y2="10.2" width="0.3" layer="16"/>
-<wire x1="56.6" y1="10.2" x2="51.35" y2="10.2" width="0.3" layer="16"/>
-<wire x1="56.6" y1="10.2" x2="63.8" y2="10.2" width="0.3" layer="1"/>
-<wire x1="67.25" y1="11.15" x2="64.75" y2="11.15" width="0.3" layer="1"/>
-<wire x1="64.75" y1="11.15" x2="63.8" y2="10.2" width="0.3" layer="1"/>
+<wire x1="12.9" y1="7.25" x2="14.05" y2="7.25" width="0.3" layer="1"/>
+<wire x1="14.4" y1="7.6" x2="14.05" y2="7.25" width="0.3" layer="1"/>
+<via x="14.4" y="7.6" extent="1-16" drill="0.45"/>
+<wire x1="25.2" y1="8.95" x2="25.2" y2="13.1" width="0.3" layer="16"/>
+<wire x1="25.2" y1="8.95" x2="23.9" y2="7.65" width="0.3" layer="16"/>
+<via x="25.2" y="13.1" extent="1-16" drill="0.45"/>
+<wire x1="25.17" y1="17.23" x2="25.17" y2="13.13" width="0.3" layer="1"/>
+<wire x1="25.2" y1="13.1" x2="25.17" y2="13.13" width="0.3" layer="1"/>
+<wire x1="23.9" y1="7.65" x2="14.45" y2="7.65" width="0.3" layer="16"/>
+<wire x1="14.4" y1="7.6" x2="14.45" y2="7.65" width="0.3" layer="16"/>
 </signal>
 <signal name="N$71">
 <contactref element="R5" pad="2"/>
 <contactref element="R4" pad="2"/>
 <contactref element="IC5" pad="7"/>
-<wire x1="71.65" y1="10.15" x2="73.55" y2="10.15" width="0.3" layer="1"/>
-<wire x1="73.55" y1="10.15" x2="74.15" y2="9.55" width="0.3" layer="1"/>
-<wire x1="74.15" y1="9.55" x2="74.15" y2="8.922" width="0.3" layer="1"/>
-<wire x1="74.15" y1="8.922" x2="74.3" y2="9.222" width="0.3" layer="1"/>
-<wire x1="74.3" y1="9.222" x2="76.8" y2="9.222" width="0.3" layer="1"/>
-</signal>
-<signal name="N$2">
-<contactref element="RN2" pad="6"/>
-<contactref element="RN3" pad="1"/>
-<wire x1="66.4" y1="42.113" x2="66.4" y2="35.037" width="0.5" layer="1"/>
+<wire x1="20.478" y1="7" x2="20.478" y2="6.25" width="0.4" layer="1"/>
+<wire x1="20.478" y1="6.25" x2="20.478" y2="3.65" width="0.4" layer="1"/>
+<wire x1="17.3" y1="6.25" x2="20.478" y2="6.25" width="0.3" layer="1"/>
 </signal>
 <signal name="BUTTON_SHLD">
 <contactref element="IC2" pad="1"/>
 <contactref element="IC1" pad="1"/>
 <contactref element="IC3" pad="1"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP8"/>
-<wire x1="70.688" y1="26.095" x2="72.445" y2="26.095" width="0.4" layer="1"/>
-<wire x1="72.445" y1="26.095" x2="73" y2="26.65" width="0.4" layer="1"/>
-<wire x1="70.688" y1="36.895" x2="72.505" y2="36.895" width="0.4" layer="1"/>
-<wire x1="70.588" y1="47.845" x2="72.355" y2="47.845" width="0.4" layer="1"/>
-<wire x1="73" y1="26.65" x2="73" y2="36.4" width="0.4" layer="1"/>
-<wire x1="73" y1="36.4" x2="72.505" y2="36.895" width="0.4" layer="1"/>
-<wire x1="73" y1="36.4" x2="73" y2="47.2" width="0.4" layer="1"/>
-<wire x1="73" y1="47.2" x2="72.355" y2="47.845" width="0.4" layer="1"/>
-<wire x1="70.688" y1="26.095" x2="72.355" y2="26.095" width="0.4" layer="1"/>
-<wire x1="72.355" y1="26.095" x2="72.75" y2="25.7" width="0.4" layer="1"/>
-<via x="72.75" y="25.7" extent="1-16" drill="0.45"/>
-<wire x1="72.75" y1="25.7" x2="72.25" y2="25.7" width="0.4" layer="16"/>
-<wire x1="72.25" y1="25.7" x2="71.95" y2="26" width="0.4" layer="16"/>
-<wire x1="71.95" y1="26" x2="61.15" y2="26" width="0.4" layer="16"/>
-<wire x1="61.15" y1="26" x2="56.85" y2="21.7" width="0.4" layer="16"/>
-<wire x1="56.85" y1="21.7" x2="45.8" y2="21.7" width="0.4" layer="16"/>
-<via x="45.05" y="22.45" extent="1-16" drill="0.45"/>
-<wire x1="45.05" y1="22.45" x2="28.8" y2="22.45" width="0.4" layer="1"/>
-<wire x1="28.8" y1="22.45" x2="27.21" y2="20.61" width="0.4" layer="1"/>
-<wire x1="27.21" y1="16.595" x2="27.21" y2="20.61" width="0.4" layer="1"/>
-<wire x1="45.8" y1="21.7" x2="45.05" y2="22.45" width="0.4" layer="16"/>
+<wire x1="70.538" y1="15.345" x2="72.595" y2="15.345" width="0.4" layer="1"/>
+<wire x1="72.595" y1="15.345" x2="73.05" y2="15.8" width="0.4" layer="1"/>
+<wire x1="70.538" y1="26.995" x2="72.655" y2="26.995" width="0.4" layer="1"/>
+<wire x1="70.538" y1="47.945" x2="72.605" y2="47.945" width="0.4" layer="1"/>
+<wire x1="73.05" y1="15.8" x2="73.05" y2="26.6" width="0.4" layer="1"/>
+<wire x1="73.05" y1="26.6" x2="72.655" y2="26.995" width="0.4" layer="1"/>
+<wire x1="73.15" y1="47.4" x2="72.605" y2="47.945" width="0.4" layer="1"/>
+<wire x1="29.702521875" y1="19.5327875" x2="29.7" y2="19.55" width="0.4" layer="1"/>
+<wire x1="27.71" y1="17.23" x2="27.729359375" y2="17.249359375" width="0.4" layer="1"/>
+<wire x1="53.975" y1="19.535" x2="53.96" y2="19.55" width="0.4" layer="16"/>
+<wire x1="53.96" y1="19.55" x2="29.7" y2="19.55" width="0.4" layer="16"/>
+<via x="53.975" y="19.535" extent="1-16" drill="0.45"/>
+<wire x1="53.975" y1="19.535" x2="53.975" y2="14.425" width="0.4" layer="1"/>
+<wire x1="59.523" y1="8.877" x2="65.26829375" y2="8.877" width="0.4" layer="1"/>
+<wire x1="68.64529375" y1="5.5" x2="71.85" y2="5.5" width="0.4" layer="1"/>
+<wire x1="71.85" y1="5.5" x2="72.595" y2="6.245" width="0.4" layer="1"/>
+<wire x1="72.595" y1="6.245" x2="72.595" y2="15.345" width="0.4" layer="1"/>
+<wire x1="65.26829375" y1="8.877" x2="68.64529375" y2="5.5" width="0.4" layer="1"/>
+<wire x1="53.975" y1="14.425" x2="59.523" y2="8.877" width="0.4" layer="1"/>
+<wire x1="73.15" y1="47.4" x2="73.15" y2="27.49" width="0.4" layer="1"/>
+<wire x1="73.15" y1="27.49" x2="72.655" y2="26.995" width="0.4" layer="1"/>
+<wire x1="27.71" y1="17.56" x2="29.7" y2="19.55" width="0.4" layer="1"/>
+<wire x1="27.71" y1="17.56" x2="27.71" y2="17.23" width="0.4" layer="1"/>
+<wire x1="29.7" y1="19.55" x2="29.702521875" y2="19.547478125" width="0.4" layer="1"/>
+<wire x1="29.702521875" y1="19.547478125" x2="29.702521875" y2="19.5327875" width="0.4" layer="1"/>
+<via x="29.7" y="19.55" extent="1-16" drill="0.45"/>
 </signal>
 <signal name="BUTTON_CLK">
 <contactref element="IC2" pad="2"/>
 <contactref element="IC1" pad="2"/>
 <contactref element="IC3" pad="2"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP9"/>
-<wire x1="70.588" y1="46.575" x2="71.925" y2="46.575" width="0.4" layer="1"/>
-<wire x1="71.925" y1="46.575" x2="72.35" y2="46.15" width="0.4" layer="1"/>
-<wire x1="72.35" y1="46.15" x2="72.35" y2="38.4" width="0.4" layer="1"/>
-<wire x1="72.35" y1="38.4" x2="71.8" y2="37.85" width="0.4" layer="1"/>
-<wire x1="71.8" y1="37.85" x2="69.5" y2="37.85" width="0.4" layer="1"/>
-<wire x1="69.5" y1="37.85" x2="69" y2="37.35" width="0.4" layer="1"/>
-<wire x1="69" y1="37.35" x2="69" y2="36.2" width="0.4" layer="1"/>
-<wire x1="69" y1="36.2" x2="69.575" y2="35.625" width="0.4" layer="1"/>
-<wire x1="70.688" y1="35.625" x2="69.575" y2="35.625" width="0.4" layer="1"/>
-<wire x1="70.688" y1="35.625" x2="71.675" y2="35.625" width="0.4" layer="1"/>
-<wire x1="72.25" y1="27.5" x2="71.85" y2="27.1" width="0.4" layer="1"/>
-<wire x1="71.85" y1="27.1" x2="69.65" y2="27.1" width="0.4" layer="1"/>
-<wire x1="69.65" y1="27.1" x2="69.1" y2="26.5" width="0.4" layer="1"/>
-<wire x1="69.1" y1="26.5" x2="69.1" y2="25.25" width="0.4" layer="1"/>
-<wire x1="69.1" y1="25.25" x2="69.525" y2="24.825" width="0.4" layer="1"/>
-<wire x1="70.688" y1="24.825" x2="69.525" y2="24.825" width="0.4" layer="1"/>
-<wire x1="72.25" y1="27.5" x2="72.25" y2="35.05" width="0.4" layer="1"/>
-<wire x1="72.25" y1="35.05" x2="71.675" y2="35.625" width="0.4" layer="1"/>
-<wire x1="69.1" y1="25.25" x2="68.55" y2="25.25" width="0.4" layer="1"/>
-<via x="68.55" y="25.25" extent="1-16" drill="0.45"/>
-<wire x1="61.55" y1="25.4" x2="57.25" y2="21.1" width="0.4" layer="16"/>
-<wire x1="57.25" y1="21.1" x2="44.8" y2="21.1" width="0.4" layer="16"/>
-<wire x1="44.8" y1="21.1" x2="44.55" y2="21.35" width="0.4" layer="16"/>
-<via x="44.55" y="21.35" extent="1-16" drill="0.45"/>
-<wire x1="44.55" y1="21.35" x2="44.25" y2="21.65" width="0.4" layer="1"/>
-<wire x1="44.25" y1="21.65" x2="30.85" y2="21.65" width="0.4" layer="1"/>
-<wire x1="29.75" y1="16.595" x2="29.75" y2="20.55" width="0.4" layer="1"/>
-<wire x1="29.75" y1="20.55" x2="30.85" y2="21.65" width="0.4" layer="1"/>
-<wire x1="61.55" y1="25.4" x2="68.4" y2="25.4" width="0.4" layer="16"/>
-<wire x1="68.4" y1="25.4" x2="68.55" y2="25.25" width="0.4" layer="16"/>
+<wire x1="70.538" y1="46.675" x2="71.875" y2="46.675" width="0.4" layer="1"/>
+<wire x1="72.5" y1="46.05" x2="71.875" y2="46.675" width="0.4" layer="1"/>
+<wire x1="68.85" y1="27.35" x2="69.45" y2="27.95" width="0.4" layer="1"/>
+<wire x1="68.85" y1="27.35" x2="68.85" y2="26.3" width="0.4" layer="1"/>
+<wire x1="68.85" y1="26.3" x2="69.425" y2="25.725" width="0.4" layer="1"/>
+<wire x1="70.538" y1="25.725" x2="69.425" y2="25.725" width="0.4" layer="1"/>
+<wire x1="72" y1="17.05" x2="71.5" y2="16.55" width="0.4" layer="1"/>
+<wire x1="72" y1="17.05" x2="72" y2="25.1" width="0.4" layer="1"/>
+<wire x1="72" y1="25.1" x2="71.375" y2="25.725" width="0.4" layer="1"/>
+<wire x1="70.538" y1="25.725" x2="71.375" y2="25.725" width="0.4" layer="1"/>
+<via x="68.4" y="14.5" extent="1-16" drill="0.45"/>
+<wire x1="54.75" y1="18.75" x2="31.75" y2="18.75" width="0.4" layer="16"/>
+<via x="31.75" y="18.75" extent="1-16" drill="0.45"/>
+<wire x1="30.25" y1="17.23" x2="30.25" y2="17.25" width="0.4" layer="1"/>
+<wire x1="30.25" y1="17.25" x2="31.75" y2="18.75" width="0.4" layer="1"/>
+<wire x1="68.4" y1="14.5" x2="62.65" y2="14.5" width="0.4" layer="16"/>
+<wire x1="62.6" y1="14.45" x2="62.65" y2="14.5" width="0.4" layer="16"/>
+<wire x1="69.45" y1="27.95" x2="70.95" y2="27.95" width="0.4" layer="1"/>
+<wire x1="70.95" y1="27.95" x2="72.5" y2="29.5" width="0.4" layer="1"/>
+<wire x1="72.5" y1="29.5" x2="72.5" y2="46.05" width="0.4" layer="1"/>
+<via x="54.75" y="18.75" extent="1-16" drill="0.45"/>
+<via x="62.6" y="14.45" extent="1-16" drill="0.45"/>
+<wire x1="59.0615875" y1="14.45" x2="54.7615875" y2="18.75" width="0.4" layer="1"/>
+<wire x1="54.75" y1="18.75" x2="54.7615875" y2="18.75" width="0.4" layer="1"/>
+<wire x1="59.0615875" y1="14.45" x2="62.6" y2="14.45" width="0.4" layer="1"/>
+<wire x1="69.3" y1="16.55" x2="68.4" y2="15.65" width="0.4" layer="1"/>
+<wire x1="68.4" y1="15.65" x2="68.4" y2="14.5" width="0.4" layer="1"/>
+<wire x1="71.5" y1="16.55" x2="69.3" y2="16.55" width="0.4" layer="1"/>
+<wire x1="70.538" y1="14.075" x2="68.775" y2="14.075" width="0.4" layer="1"/>
+<wire x1="68.775" y1="14.075" x2="68.4" y2="14.45" width="0.4" layer="1"/>
+<wire x1="68.4" y1="14.45" x2="68.4" y2="14.5" width="0.4" layer="1"/>
 </signal>
 <signal name="BUTTON_DATA">
 <contactref element="IC1" pad="9"/>
 <contactref element="RASPBERRY_PI_PICO" pad="GP12"/>
-<wire x1="76.112" y1="17.205" x2="75.305" y2="17.205" width="0.4" layer="1"/>
-<wire x1="75.305" y1="17.205" x2="74.1" y2="16" width="0.4" layer="1"/>
-<wire x1="74.1" y1="16" x2="58.65" y2="16" width="0.4" layer="1"/>
-<via x="57.5" y="17.2" extent="1-16" drill="0.45"/>
-<wire x1="57.5" y1="17.2" x2="54.75" y2="19.95" width="0.4" layer="16"/>
-<via x="44.6" y="19.95" extent="1-16" drill="0.45"/>
-<wire x1="44.6" y1="19.95" x2="54.75" y2="19.95" width="0.4" layer="16"/>
-<wire x1="44.6" y1="19.95" x2="41.1" y2="19.95" width="0.4" layer="1"/>
-<wire x1="41.1" y1="19.95" x2="39.91" y2="18.76" width="0.4" layer="1"/>
-<wire x1="39.91" y1="16.595" x2="39.91" y2="18.76" width="0.4" layer="1"/>
-<wire x1="58.65" y1="16" x2="57.5" y2="17.2" width="0.4" layer="1"/>
+<via x="51.2" y="13" extent="1-16" drill="0.45"/>
+<via x="42.35" y="13" extent="1-16" drill="0.45"/>
+<wire x1="51.2" y1="13" x2="42.35" y2="13" width="0.4" layer="16"/>
+<wire x1="40.4" y1="17.22" x2="40.4" y2="14.95" width="0.4" layer="1"/>
+<wire x1="40.4" y1="14.95" x2="42.35" y2="13" width="0.4" layer="1"/>
+<wire x1="40.41" y1="17.23" x2="40.4" y2="17.22" width="0.4" layer="1"/>
+<wire x1="59.1620875" y1="8.05" x2="64.9" y2="8.05" width="0.4" layer="1"/>
+<wire x1="64.9" y1="8.05" x2="68.35" y2="4.6" width="0.4" layer="1"/>
+<wire x1="68.35" y1="4.6" x2="73.3" y2="4.6" width="0.4" layer="1"/>
+<wire x1="75.962" y1="6.455" x2="75.155" y2="6.455" width="0.4" layer="1"/>
+<wire x1="75.155" y1="6.455" x2="73.3" y2="4.6" width="0.4" layer="1"/>
+<wire x1="59.1620875" y1="8.05" x2="54.2120875" y2="13" width="0.4" layer="1"/>
+<wire x1="54.2120875" y1="13" x2="51.2" y2="13" width="0.4" layer="1"/>
 </signal>
 <signal name="N$3">
 <contactref element="IC1" pad="10"/>
 <contactref element="IC2" pad="9"/>
-<wire x1="76.112" y1="18.475" x2="74.325" y2="18.475" width="0.3" layer="1"/>
-<wire x1="74.325" y1="18.475" x2="73.75" y2="19.05" width="0.3" layer="1"/>
-<wire x1="73.75" y1="19.05" x2="73.8" y2="27.2" width="0.3" layer="1"/>
-<wire x1="73.8" y1="27.2" x2="74.605" y2="28.005" width="0.3" layer="1"/>
-<wire x1="76.112" y1="28.005" x2="74.605" y2="28.005" width="0.3" layer="1"/>
+<wire x1="75.962" y1="7.725" x2="74.175" y2="7.725" width="0.4" layer="1"/>
+<wire x1="74.175" y1="7.725" x2="73.6" y2="8.3" width="0.4" layer="1"/>
+<wire x1="73.6" y1="8.3" x2="73.6" y2="17.15" width="0.4" layer="1"/>
+<wire x1="75.962" y1="18.105" x2="74.555" y2="18.105" width="0.4" layer="1"/>
+<wire x1="74.555" y1="18.105" x2="73.6" y2="17.15" width="0.4" layer="1"/>
 </signal>
 <signal name="N$4">
 <contactref element="IC3" pad="9"/>
 <contactref element="IC2" pad="10"/>
-<wire x1="76.112" y1="29.275" x2="74.325" y2="29.275" width="0.3" layer="1"/>
-<wire x1="74.325" y1="29.275" x2="73.75" y2="29.85" width="0.3" layer="1"/>
-<wire x1="73.75" y1="29.85" x2="73.75" y2="38.3" width="0.3" layer="1"/>
-<wire x1="73.75" y1="38.3" x2="74.455" y2="38.955" width="0.3" layer="1"/>
-<wire x1="76.012" y1="38.955" x2="74.455" y2="38.955" width="0.3" layer="1"/>
+<wire x1="75.962" y1="19.375" x2="74.175" y2="19.375" width="0.3" layer="1"/>
+<wire x1="74.175" y1="19.375" x2="73.7" y2="19.85" width="0.3" layer="1"/>
+<wire x1="73.7" y1="19.85" x2="73.7" y2="38.4" width="0.3" layer="1"/>
+<wire x1="73.7" y1="38.4" x2="74.405" y2="39.055" width="0.3" layer="1"/>
+<wire x1="75.962" y1="39.055" x2="74.405" y2="39.055" width="0.3" layer="1"/>
 </signal>
 </signals>
-<errors>
-<approved hash="18,29,001ea87d6870c013"/>
-<approved hash="18,29,b912c37103647907"/>
-<approved hash="18,29,1a62a20162f4da97"/>
-<approved hash="18,29,0764b16ab06ac101"/>
-<approved hash="18,29,1dd8dcd9aaae4800"/>
-<approved hash="18,29,1de383e38e6a6100"/>
-<approved hash="18,29,075f985194ae9e00"/>
-<approved hash="18,29,e7a40c2e0d2ef481"/>
-<approved hash="18,29,fce00861166a1580"/>
-</errors>
+<mfgpreviewcolors>
+<mfgpreviewcolor name="soldermaskcolor" color="0xC8008000"/>
+<mfgpreviewcolor name="silkscreencolor" color="0xFFFEFEFE"/>
+<mfgpreviewcolor name="backgroundcolor" color="0xFF282828"/>
+<mfgpreviewcolor name="coppercolor" color="0xFFFFBF00"/>
+<mfgpreviewcolor name="substratecolor" color="0xFF786E46"/>
+</mfgpreviewcolors>
 </board>
 </drawing>
 <compatibility>
 <note version="6.3" minversion="6.2.2" severity="warning">
 Since Version 6.2.2 text objects can contain more than one line,
 which will not be processed correctly with this version.
+</note>
+<note version="8.2" severity="warning">
+Since Version 8.2, EAGLE supports online libraries. The ids
+of those online libraries will not be understood (or retained)
+with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports URNs for individual library
+assets (packages, symbols, and devices). The URNs of those assets
+will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
 </note>
 </compatibility>
 </eagle>


### PR DESCRIPTION
- Changed Pico footprint to THT. Can also still be used for SMD soldering of the Pico.
- Relocated components.
- Relayouted traces.