### PR TITLE
ADC based button source 

### DIFF
--- a/Firmware/Buttons.cpp
+++ b/Firmware/Buttons.cpp
@@ -34,6 +34,7 @@
 #include "Nudge.h"
 #include "Outputs.h"
 #include "BootselButton.h"
+#include "ADCManager.h"
 #include "Plunger/Plunger.h"
 #include "Plunger/ZBLaunch.h"
 #include "IRRemote/IRCommand.h"
@@ -555,6 +556,11 @@ static const std::unordered_map<std::string, uint8_t> usbKeyNames{
 // type: "clock",         // button is pressed at certain times of day
 //   // TBD
 //
+// type: "adc",           // ADC based source
+//   adc: "<adc>",        // the adc entry, for example "pico_adc[0]", required
+//   threshold: <number>, // the adc threshold level to compare against the adc reading, default 0
+//   above: <bool>,       // true (default) -> read as ON when the adc reading is above the threshold
+//                        // false -> read as ON when the adc reading is below the threshold
 //
 // <Action> object details:
 // action: {
@@ -1053,6 +1059,73 @@ Button::Source *Button::ParseSource(
             
         // return the new source
         return dofSource;
+    }
+    else if (srcType == "adc")
+    {
+        // An ADC source is required
+        if (auto *adcVal = srcVal->Get("adc") ; !adcVal->IsUndefined())
+        {
+	        struct ADCEntry
+	        {
+	            ADCEntry(ADC* adc, int channel) : adc(adc), channel(channel) {}
+	            ADC* adc;
+	            int channel;
+	        };
+	
+	        std::unordered_map<std::string, ADCEntry> adcEntryMap;
+	
+	        // add ADC entries from the ADC Manager list
+	        adcManager.Enumerate([&adcEntryMap](ADC *adc)
+	        {
+	            // add the adc under a key
+	            auto Add = [&adcEntryMap](const char *key, ADC *adc)
+	            {
+	                // add an entry for the device with no suffix, as shorthand for
+	                // "device[0]" (logical channel 0 on the device)
+	                adcEntryMap.emplace(key, ADCEntry(adc, 0));
+	                Log(LOG_DEBUG, "ADCSource: added key %s for %s\n", key, adc->DisplayName());
+	                // add channel-numbered keys, with [n] suffixes
+	                for (int i = 0, n = adc->GetNumLogicalChannels() ; i < n ; ++i)
+	                {
+	                    char subkey[32];
+	                    snprintf(subkey, sizeof(subkey), "%s[%d]", key, i);
+	                    adcEntryMap.emplace(subkey, ADCEntry(adc, i));
+	                    Log(LOG_DEBUG, "ADCSource: added subkey %s for %s\n", subkey, adc->DisplayName());
+	                }
+	            };
+	
+	            // add an entry under its main key
+	            Add(adc->ConfigKey(), adc);
+	
+	            // add it under its alternate key, if it has one
+	            if (const auto* altKey = adc->AltConfigKey(); altKey != nullptr)
+	            {
+	                Add(altKey, adc);
+	                Log(LOG_DEBUG, "ADCSource: added altkey %s for %s\n", altKey, adc->DisplayName());
+	            }
+	        });
+            // look it up
+            auto adcStr = adcVal->String();
+            if (auto it = adcEntryMap.find(adcStr); it != adcEntryMap.end())
+            {
+                // select the named ADC entry
+                ADCEntry adcEntry = it->second;
+                int32_t threshold = srcVal->Get("threshold")->Int32(32767);
+                bool above = srcVal->Get("above")->Bool(true);
+                Log(LOG_CONFIG, "ADCSource: %s %d %s %d\n", 
+					adcEntry.adc->DisplayName(), adcEntry.channel, above ? "above" : "below", threshold);
+                return new Button::ADCSource(adcEntry.adc, adcEntry.channel, above, threshold);
+            }
+            else
+            {
+                // error - ADC not found
+                return Log(LOG_ERROR, "ADCSource: ADC \"%s\" is unknown, or not configured\n", adcStr.c_str()), nullptr;
+            }
+        }
+        else
+        {
+            return Log(LOG_ERROR, "ADCSource: an \"adc\" item is required.\n"), nullptr;
+        }
     }
     else
     {
@@ -2639,6 +2712,28 @@ void Button::DOFSource::PopulateDesc(PinscapePico::ButtonDesc *desc) const
     desc->sourcePort = portNum;
 }
 
+// ---------------------------------------------------------------------------
+//
+// ADC Source
+//
+Button::ADCSource::ADCSource(ADC* adc, int channel, bool above, int32_t threshold) :
+    adc(adc), channel(channel), above(above), threshold(threshold) {
+    // enable sampling on the ADC
+    adc->EnableSampling();
+    // build the friendly name based on the ADC name
+    fullName = Format("ADCSource(%s %i %s %i)", adc->DisplayName(), channel, above ? "above" : "below", threshold);
+    Log(LOG_DEBUG, "ADCSource: %s\n", fullName);
+}
+
+bool Button::ADCSource::Poll() {
+    // Read the adc
+    ADC::Sample s = adc->ReadNorm(channel);
+    // compare to the threshold
+    if (above) {
+        return s.sample > threshold;
+    }
+    return s.sample < threshold;
+}
 
 // ---------------------------------------------------------------------------
 //

--- a/Firmware/Buttons.h
+++ b/Firmware/Buttons.h
@@ -119,6 +119,7 @@ class PCA9555;
 class C74HC165;
 class JSONParser;
 class IRCommandDesc;
+class ADC;
 
 
 // Abstract button class.  This defines a logical button, which can be
@@ -748,6 +749,33 @@ public:
         // OutputManager::Port is an incomplete nested class at this point,
         // and C++ doesn't currently have any way to declare such a thing.
         void *port = nullptr;
+    };
+
+    // ADC source. This source can translate analog values to a digital on/off.
+    class ADCSource : public Source
+    {
+    public:
+        ADCSource(ADC* adc, int channel, bool above, int32_t threshold);
+        virtual bool Poll() override;
+        // display name for log messages
+        virtual const char *FullName(char *buf, size_t buflen) const override { return fullName; }
+        // populate a vendor interface button descriptor
+        virtual void PopulateDesc(PinscapePico::ButtonDesc *desc) const override { 
+            desc->sourceType = PinscapePico::ButtonDesc::SRC_ADC;
+            desc->sourcePort = channel;
+        }
+
+    private:
+        // The ADC and channel
+        ADC* adc;
+        int channel;
+        // When true, the source is considered enabled when the threshold is above the reading from the sensor
+        bool above;
+        // threshold level
+        int32_t threshold;
+
+        // full name of the AdcSource button; we build this based on the ADC's display name
+        const char *fullName;
     };
 
     // -----------------------------------------------------------------------

--- a/Firmware/JSONConfigRef.txt
+++ b/Firmware/JSONConfigRef.txt
@@ -122,7 +122,7 @@ buttons[].source object required
   software sources, such as the plunger and nudge subsystems, or the IR
   remote control receiver.
 
-buttons[].source.type string{"gpio" "bootsel" "pca9555" "74hc165" "nudge" "IR" "plunger" "zblaunch" "clock" "output"} required
+buttons[].source.type string{"gpio" "bootsel" "pca9555" "74hc165" "nudge" "IR" "plunger" "zblaunch" "clock" "output" "adc"} required
   The source type.  See the source types below for more details.
 
 buttons[].source.type="output"
@@ -529,6 +529,29 @@ buttons[].source.type="zblaunch".modal bool optional
   when ZB Launch Mode is in effect, as set through the DOF port assigned
   as the ZB Launch indicator.  Set this to false to trigger the button
   on a ZB Launch gesture even when the mode isn't in effect.
+
+buttons[].source.type="adc"
+  Sets up the logical button to trigger whenever an ADC (analog to
+  digital) value is either above or below the configured threshold value.
+
+buttons[].source.type="adc".adc string required
+  The name of the ADC device to use as the input for the button.
+  If you configure an ADC device with multiple channels, and you want
+  to use one of those for a potentiometer plunger input, you'll have
+  to set this to specify which channel to use.  For the Pico on-board
+  ADC, set this to "pico_adc" to use the first configured channel for
+  the plunger, "pico_adc[1]" to use the second channel, "pico_adc[2]"
+  for the third channel, and so on.
+
+buttons[].source.type="adc".above bool optional
+  If this is set to true, which is the default, the button only triggers
+  when the analog reading is above the set threshold value. When set to
+  false, the button only triggers when the analog reading is below the
+  set threshold value.
+
+buttons[].source.type="adc".threshold number optional
+  Sets the value at which the button will trigger if it is above or below
+  this value. The range is 0..65535 and the default is 32767.
 
 buttons[].source.active string{high low} optional
   "high" for a button whose port reads logic "1" when pressed, "low" for

--- a/GUIConfigTool/ButtonTesterWin.cpp
+++ b/GUIConfigTool/ButtonTesterWin.cpp
@@ -1560,16 +1560,18 @@ void ButtonTesterWin::PaintOffScreen(HDC hdc0)
             pt.x = max(pt.x + 8, startX + typeColWidth);
 
 			// source description
-			static const char *srcNames[] ={ "None", "GPIO", "BOOTSEL", "PCA9555", "74HC165", "Accelerometer", "Plunger", "ZB Launch", "IR RX", "Time", "Out Port" };
+			static const char *srcNames[] ={ "None", "GPIO", "BOOTSEL", "PCA9555", "74HC165", "Accelerometer", "Plunger", "ZB Launch", "IR RX", "Time", "Out Port", "ADC"};
 			char srcDesc[32];
-			if (pDesc->sourceType == PinscapePico::ButtonDesc::SRC_GPIO)
-				sprintf_s(srcDesc, "GPIO (GP%d)", pDesc->sourcePort);
-			else if (pDesc->sourceType == PinscapePico::ButtonDesc::SRC_PCA9555)
-				sprintf_s(srcDesc, "PCA9555[%d] port IO%d_%d", pDesc->sourceUnit, pDesc->sourcePort / 8, pDesc->sourcePort % 8);
-			else if (pDesc->sourceType == PinscapePico::ButtonDesc::SRC_74HC165)
-				sprintf_s(srcDesc, "74HC165[%d] chip %d port %c", pDesc->sourceUnit, pDesc->sourcePort / 8, (pDesc->sourcePort % 8) + 'A');
-			else if (pDesc->sourceType == PinscapePico::ButtonDesc::SRC_OUTPORT)
-				sprintf_s(srcDesc, "Output Port #%d", pDesc->sourcePort);
+            if (pDesc->sourceType == PinscapePico::ButtonDesc::SRC_GPIO)
+                sprintf_s(srcDesc, "GPIO (GP%d)", pDesc->sourcePort);
+            else if (pDesc->sourceType == PinscapePico::ButtonDesc::SRC_PCA9555)
+                sprintf_s(srcDesc, "PCA9555[%d] port IO%d_%d", pDesc->sourceUnit, pDesc->sourcePort / 8, pDesc->sourcePort % 8);
+            else if (pDesc->sourceType == PinscapePico::ButtonDesc::SRC_74HC165)
+                sprintf_s(srcDesc, "74HC165[%d] chip %d port %c", pDesc->sourceUnit, pDesc->sourcePort / 8, (pDesc->sourcePort % 8) + 'A');
+            else if (pDesc->sourceType == PinscapePico::ButtonDesc::SRC_OUTPORT)
+                sprintf_s(srcDesc, "Output Port #%d", pDesc->sourcePort);
+            else if (pDesc->sourceType == PinscapePico::ButtonDesc::SRC_ADC)
+                sprintf_s(srcDesc, "ADC channel [%d]", pDesc->sourcePort);
 			else
 				sprintf_s(srcDesc, "%s", (pDesc->sourceType < _countof(srcNames)) ? srcNames[pDesc->sourceType] : "Unknown");
 

--- a/USBProtocol/VendorIfcProtocol.h
+++ b/USBProtocol/VendorIfcProtocol.h
@@ -2192,6 +2192,7 @@ namespace PinscapePico
         static const uint8_t SRC_CLOCK = 0x09;     // time-of-day trigger
         static const uint8_t SRC_OUTPORT = 0x0A;   // output port trigger (DOF port); button is ON when the DOF port PWM level in a specified range
         static const uint8_t SRC_NULL = 0x0B;      // null source; always reads as off
+        static const uint8_t SRC_ADC = 0x0C;       // adc source
 
         // Source device details.  These elements vary by source type:
         //
@@ -2210,6 +2211,8 @@ namespace PinscapePico
         //
         // - Output (DOF) port: unit is zero, port is the output port number
         //
+        // - ADC: port is the channel
+        // 
         // These fields are unused for other source types.
         uint8_t sourceUnit;
         uint8_t sourcePort;


### PR DESCRIPTION
As discussed in #45, this change adds support for an analog device to be used as a button source. 

The new source type is defined as:
```
type: "adc",           // ADC based source
  adc: "<adc>",        // the adc entry, for example "pico_adc[0]", required
  threshold: <number>, // the adc threshold level to compare against the adc reading, default 0
  above: <bool>,       // true (default) -> read as ON when the adc reading is above the threshold
                       // false -> read as ON when the adc reading is below the threshold
```
An example configuration entry would be:
```
buttons: [
        {
            source: { type: "adc", adc: "pico_adc[1]", threshold: 3000, above: true },
            action: { type: "key", key: "up"}
        },
]
```