### PR TITLE
Trivial fix for the mma8451q JSON example

### DIFF
--- a/GUIConfigTool/Help/JSONConfigRef.htm
+++ b/GUIConfigTool/Help/JSONConfigRef.htm
@@ -5919,7 +5919,7 @@ For an introduction to the JSON syntax and the overall file layout, refer to
         i2c: 0,
         addr: 0x1D,
         interrupt: 7,
-        gRange, 2,
+        gRange: 2,
      },
   }
 </div>


### PR DESCRIPTION
Noticed this when doing a copy/paste of the example.